### PR TITLE
fix(client): form-encode yaml validate body

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -174,15 +174,18 @@ func (c *Client) DeleteWithParams(kind, id string, params url.Values) (*Response
 	return c.doWithRetry("DELETE", u, nil)
 }
 
-// PostYAML sends a POST with YAML content type (for yaml validate endpoint).
+// PostYAML sends a POST to the YAML validation endpoint.
+// The Semaphore v1alpha /yaml endpoint expects a form-encoded body with a
+// yaml_definition parameter, not a raw YAML body.
 func (c *Client) PostYAML(kind string, yamlBody []byte) (*Response, error) {
 	u := fmt.Sprintf("https://%s/api/%s/%s", c.host, c.apiVersion, kind)
 	log.Printf("POST (yaml) %s", u)
-	req, err := http.NewRequest("POST", u, bytes.NewReader(yamlBody))
+	form := url.Values{"yaml_definition": {string(yamlBody)}}
+	req, err := http.NewRequest("POST", u, strings.NewReader(form.Encode()))
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/yaml")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", c.token))
 	req.Header.Set("User-Agent", UserAgent)
 	resp, err := c.httpClient.Do(req)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -555,5 +556,61 @@ func TestHTTPMethods(t *testing.T) {
 				t.Errorf("HTTP method = %q, want %q", gotMethod, tc.wantMethod)
 			}
 		})
+	}
+}
+
+// ---- PostYAML wire-format tests ---------------------------------------------
+
+func TestPostYAMLFormEncodedBody(t *testing.T) {
+	var gotContentType string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(200)
+		w.Write([]byte(`{"message":"YAML definition is valid."}`))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	c := newTestClient(host, "tok")
+	yaml := []byte("version: v1.0\nname: test\n")
+	resp, err := c.PostYAML("yaml", yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("Content-Type = %q, want application/x-www-form-urlencoded", gotContentType)
+	}
+	parsed, err := url.ParseQuery(string(gotBody))
+	if err != nil {
+		t.Fatalf("body is not form-encoded: %v (body=%q)", err, string(gotBody))
+	}
+	if got := parsed.Get("yaml_definition"); got != string(yaml) {
+		t.Errorf("yaml_definition = %q, want %q", got, string(yaml))
+	}
+}
+
+func TestPostYAMLEndpointURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	c := newTestClient(host, "tok")
+	_, err := c.PostYAML("yaml", []byte("version: v1.0\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantPath := "/api/v1alpha/yaml"
+	if gotPath != wantPath {
+		t.Errorf("path = %q, want %q", gotPath, wantPath)
 	}
 }


### PR DESCRIPTION
## Summary

- `sem-ai yaml validate` was unusable — every call returned `Missing required post parameter yaml_definition` regardless of YAML correctness.
- Root cause: `PostYAML` in `pkg/client/client.go` sent the YAML as a raw body with `Content-Type: application/yaml`, but the v1alpha `/yaml` endpoint expects `application/x-www-form-urlencoded` with a `yaml_definition` field.
- Switch the request to form-encoded with the YAML in the `yaml_definition` parameter. Added two wire-format tests covering Content-Type, body shape, and endpoint path.

## Test plan

- [x] `go test ./pkg/client/...` — new tests pass
- [x] `go test ./...` — full suite green
- [x] Live test against `semaphore.semaphoreci.com`:
  ```
  $ sem-ai yaml validate --file good.yml
  {"valid": true, "message": "pipeline YAML is valid"}

  $ sem-ai yaml validate --file bad.yml
  {"valid": false, "errors": "{:malformed, ...}"}
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)