### PR TITLE
feat(deploy): full API parity for create + add update

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -31,15 +31,121 @@ sem-ai pipeline promote <id> --target "Staging" --confirm --override
 sem-ai pipeline promote <id> --target "Production" --confirm --param version=1.2.3
 ```
 
-## Deployment targets
+## Deployment targets — read
+
 ```bash
 sem-ai deploy targets --project my-app    # list
 sem-ai deploy show <target-id>            # details
 sem-ai deploy history <target-id>         # history
+```
+
+## Deployment targets — lifecycle
+
+```bash
 sem-ai deploy activate <target-id>        # enable
-sem-ai deploy deactivate <target-id>      # disable
+sem-ai deploy deactivate <target-id>      # cordon (disable)
 sem-ai deploy delete <target-id>          # remove
 ```
+
+## Deployment targets — create
+
+`sem-ai deploy create <name>` builds the target's restriction surface from flags. **If a rule type (BRANCH / TAG / PR) has no flag, that type is implicitly blocked** — this is the right safe default for tag-only release targets.
+
+### Tag-only release target (auto-promote only)
+```bash
+sem-ai deploy create release \
+  --project my-app \
+  --description "Auto-promoted on v* tag" \
+  --tag-regex '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+  --subject-auto \
+  --env-var GITHUB_TOKEN=<personal-access-token>
+```
+Result: only auto-promotion (from `auto_promote.when`) on tags matching the regex can trigger this. Manual clicks blocked. Branch/PR pipelines cannot promote here.
+
+### Main-branch-only snapshot target
+```bash
+sem-ai deploy create snapshot \
+  --project my-app \
+  --branch-exact main \
+  --subject-any
+```
+Result: any team member can promote, but only on the `main` branch.
+
+### Object rules — pick per type
+
+| Flag | Effect |
+|------|--------|
+| `--tag-regex <pattern>` | Allow tags matching Perl-compatible regex |
+| `--tag-exact <name>` | Allow exact tag name only |
+| `--allow-all-tags` | Allow promotion from any tag |
+| `--branch-regex <pattern>` | Allow branches matching regex |
+| `--branch-exact <name>` | Allow exact branch name only |
+| `--allow-all-branches` | Allow promotion from any branch |
+| `--allow-prs` | Allow promotion from pull requests |
+
+You can pass multiple type flags in one call (e.g. `--branch-exact main --tag-regex '^v[0-9].*'` to allow main-branch promotions AND v-tag promotions).
+
+### Subject rules — who can trigger
+
+| Flag | Effect |
+|------|--------|
+| `--subject-any` | Anyone with project access |
+| `--subject-user <uuid-or-git_login>` | Specific user (repeatable; UUID auto-detected vs git_login) |
+| `--subject-role <role>` | Members of a role like `Admin` or `Contributor` (repeatable) |
+| `--subject-auto` | Auto-promotion conditions only — blocks manual clicks |
+
+If no subject flag is passed, the API default applies (typically `ANY`).
+
+### Target-bound secrets
+
+```bash
+--env-var NAME=VALUE                  # repeatable
+--file /etc/conf=/local/source.txt    # repeatable; base64-encodes content
+```
+
+Secrets bound to a deployment target are only visible to pipelines triggered THROUGH that target — more restrictive than project-level secrets. Prefer these for release credentials (e.g. `GITHUB_TOKEN` for goreleaser, deploy keys, registry creds).
+
+### Deployment history filters (bookmarks)
+
+```bash
+--bookmark1 staging   --bookmark2 us-east-1   --bookmark3 v1.2
+```
+Pure metadata for filtering the deployment history page on the Semaphore web UI. Does NOT restrict who/what can trigger — that's `--subject-*` / `--branch-*` / `--tag-*`.
+
+## Deployment targets — update
+
+`sem-ai deploy update <target-id>` PATCHes the target. Only flags you pass are sent; everything else is preserved server-side.
+
+```bash
+# Tighten the release tag pattern
+sem-ai deploy update <id> --tag-regex '^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+# Rotate a target-bound secret
+sem-ai deploy update <id> --env-var GITHUB_TOKEN=<new-pat>
+
+# Rename
+sem-ai deploy update <id> --name release-v2
+
+# Replace subject rules with a more restrictive set
+sem-ai deploy update <id> --subject-role Admin --subject-auto
+```
+
+Note: list/array fields (`object_rules`, `subject_rules`, `env_vars`, `files`) are **replaced** by what you send — not merged. To preserve existing rules, re-pass them alongside the new ones, OR fetch the current state via `deploy show` first.
+
+## Pipeline YAML reference
+
+In the pipeline's `promotions:` block, reference the target by name:
+
+```yaml
+promotions:
+  - name: Publish GitHub Release
+    pipeline_file: release.yml
+    auto_promote:
+      when: "tag =~ '^v.*' AND result = 'passed'"
+    deployment_target: release
+```
+
+The `deployment_target:` line enforces gating on BOTH auto and manual triggers, unlike `auto_promote.when` which only gates auto-firing.
 
 ## Full deploy workflow
 ```bash
@@ -60,3 +166,5 @@ sem-ai promote-and-wait <id> --target "Production" --confirm
 - Without `--confirm`: dry run only.
 - Always verify tests before promoting.
 - `--override` bypasses conditions — confirm with user first.
+- Creating a deployment target without any `--subject-*` flag may default to `ANY` (anyone can trigger) — surface this when scaffolding release targets and prefer `--subject-auto` for tag-only release flows.
+- `deploy update` REPLACES list fields. To merge new rules into existing ones, fetch current state with `deploy show` first.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
+	"regexp"
+	"strings"
 
 	"github.com/semaphoreio/sem-ai/pkg/client"
 	"github.com/semaphoreio/sem-ai/pkg/config"
@@ -19,8 +23,8 @@ var deployCmd = &cobra.Command{
 var deployTargetsProjectFlag string
 
 var deployTargetsCmd = &cobra.Command{
-	Use:   "targets",
-	Short: "List deployment targets for a project",
+	Use:     "targets",
+	Short:   "List deployment targets for a project",
 	Example: `  sem-ai deploy targets --project my-project`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.IsConfigured() {
@@ -175,38 +179,202 @@ var deployDeleteCmd = &cobra.Command{
 	},
 }
 
-var (
-	deployCreateProjectFlag string
-	deployCreateDescFlag    string
-	deployCreateURLFlag     string
-	deployCreateBranchFlag  []string
-)
+// deployTargetSpec holds the flag values for create + update.
+type deployTargetSpec struct {
+	projectFlag string
+	description string
+	url         string
+
+	tagRegex         string
+	tagExact         string
+	branchRegex      string
+	branchExact      string
+	allowAllBranches bool
+	allowAllTags     bool
+	allowPRs         bool
+
+	subjectAny   bool
+	subjectUsers []string
+	subjectRoles []string
+	subjectAuto  bool
+
+	envVars []string
+	files   []string
+
+	bookmark1 string
+	bookmark2 string
+	bookmark3 string
+
+	uniqueToken string
+}
+
+var uuidRegexp = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// toBody builds the JSON request body. Empty fields are omitted so that PATCH
+// callers can pass a partial update without nuking other fields.
+func (s *deployTargetSpec) toBody(name string) (map[string]any, error) {
+	body := map[string]any{}
+	if name != "" {
+		body["name"] = name
+	}
+	if s.description != "" {
+		body["description"] = s.description
+	}
+	if s.url != "" {
+		body["url"] = s.url
+	}
+	if s.bookmark1 != "" {
+		body["bookmark_parameter1"] = s.bookmark1
+	}
+	if s.bookmark2 != "" {
+		body["bookmark_parameter2"] = s.bookmark2
+	}
+	if s.bookmark3 != "" {
+		body["bookmark_parameter3"] = s.bookmark3
+	}
+
+	objRules := []map[string]any{}
+	if s.allowAllBranches {
+		objRules = append(objRules, map[string]any{"type": "BRANCH", "match_mode": "ALL", "pattern": ""})
+	}
+	if s.branchExact != "" {
+		objRules = append(objRules, map[string]any{"type": "BRANCH", "match_mode": "EXACT", "pattern": s.branchExact})
+	}
+	if s.branchRegex != "" {
+		objRules = append(objRules, map[string]any{"type": "BRANCH", "match_mode": "REGEX", "pattern": s.branchRegex})
+	}
+	if s.allowAllTags {
+		objRules = append(objRules, map[string]any{"type": "TAG", "match_mode": "ALL", "pattern": ""})
+	}
+	if s.tagExact != "" {
+		objRules = append(objRules, map[string]any{"type": "TAG", "match_mode": "EXACT", "pattern": s.tagExact})
+	}
+	if s.tagRegex != "" {
+		objRules = append(objRules, map[string]any{"type": "TAG", "match_mode": "REGEX", "pattern": s.tagRegex})
+	}
+	if s.allowPRs {
+		objRules = append(objRules, map[string]any{"type": "PR", "match_mode": "ALL", "pattern": ""})
+	}
+	if len(objRules) > 0 {
+		body["object_rules"] = objRules
+	}
+
+	subjRules := []map[string]any{}
+	if s.subjectAny {
+		subjRules = append(subjRules, map[string]any{"type": "ANY", "subject_id": ""})
+	}
+	for _, u := range s.subjectUsers {
+		entry := map[string]any{"type": "USER"}
+		if uuidRegexp.MatchString(u) {
+			entry["subject_id"] = u
+		} else {
+			entry["git_login"] = u
+		}
+		subjRules = append(subjRules, entry)
+	}
+	for _, r := range s.subjectRoles {
+		subjRules = append(subjRules, map[string]any{"type": "ROLE", "subject_id": r})
+	}
+	if s.subjectAuto {
+		subjRules = append(subjRules, map[string]any{"type": "AUTO", "subject_id": ""})
+	}
+	if len(subjRules) > 0 {
+		body["subject_rules"] = subjRules
+	}
+
+	envVars := []map[string]any{}
+	for _, kv := range s.envVars {
+		name, value, ok := strings.Cut(kv, "=")
+		if !ok {
+			return nil, fmt.Errorf("--env-var must be NAME=VALUE, got %q", kv)
+		}
+		envVars = append(envVars, map[string]any{"name": name, "value": value})
+	}
+	if len(envVars) > 0 {
+		body["env_vars"] = envVars
+	}
+
+	files := []map[string]any{}
+	for _, pf := range s.files {
+		path, local, ok := strings.Cut(pf, "=")
+		if !ok {
+			return nil, fmt.Errorf("--file must be PATH=LOCAL_SOURCE, got %q", pf)
+		}
+		content, err := os.ReadFile(local)
+		if err != nil {
+			return nil, fmt.Errorf("--file %s: %w", local, err)
+		}
+		files = append(files, map[string]any{"path": path, "content": base64.StdEncoding.EncodeToString(content)})
+	}
+	if len(files) > 0 {
+		body["files"] = files
+	}
+
+	return body, nil
+}
+
+func bindDeploySpecFlags(cmd *cobra.Command, s *deployTargetSpec) {
+	cmd.Flags().StringVar(&s.projectFlag, "project", "", "project name or ID (required on create)")
+	cmd.Flags().StringVar(&s.description, "description", "", "target description")
+	cmd.Flags().StringVar(&s.url, "url", "", "target URL")
+
+	cmd.Flags().StringVar(&s.tagRegex, "tag-regex", "", "allow tags matching regex (e.g. '^v[0-9].*')")
+	cmd.Flags().StringVar(&s.tagExact, "tag-exact", "", "allow exact tag name")
+	cmd.Flags().StringVar(&s.branchRegex, "branch-regex", "", "allow branches matching regex")
+	cmd.Flags().StringVar(&s.branchExact, "branch-exact", "", "allow exact branch name")
+	cmd.Flags().BoolVar(&s.allowAllBranches, "allow-all-branches", false, "allow promotion from any branch")
+	cmd.Flags().BoolVar(&s.allowAllTags, "allow-all-tags", false, "allow promotion from any tag")
+	cmd.Flags().BoolVar(&s.allowPRs, "allow-prs", false, "allow promotion from pull requests")
+
+	cmd.Flags().BoolVar(&s.subjectAny, "subject-any", false, "allow anyone to trigger the promotion")
+	cmd.Flags().StringArrayVar(&s.subjectUsers, "subject-user", nil, "allow specific user (UUID or git_login); repeatable")
+	cmd.Flags().StringArrayVar(&s.subjectRoles, "subject-role", nil, "allow members of role (e.g. Admin, Contributor); repeatable")
+	cmd.Flags().BoolVar(&s.subjectAuto, "subject-auto", false, "allow auto-promotion conditions to trigger the promotion")
+
+	cmd.Flags().StringArrayVar(&s.envVars, "env-var", nil, "target-bound env var NAME=VALUE; repeatable")
+	cmd.Flags().StringArrayVar(&s.files, "file", nil, "target-bound file PATH=LOCAL_SOURCE (base64-encoded); repeatable")
+
+	cmd.Flags().StringVar(&s.bookmark1, "bookmark1", "", "deployment history filter (bookmark_parameter1)")
+	cmd.Flags().StringVar(&s.bookmark2, "bookmark2", "", "deployment history filter (bookmark_parameter2)")
+	cmd.Flags().StringVar(&s.bookmark3, "bookmark3", "", "deployment history filter (bookmark_parameter3)")
+
+	cmd.Flags().StringVar(&s.uniqueToken, "unique-token", "", "explicit idempotency UUID (default: generate fresh)")
+}
+
+var deployCreateSpec = &deployTargetSpec{}
 
 var deployCreateCmd = &cobra.Command{
 	Use:   "create <name>",
 	Short: "Create a deployment target",
 	Args:  cobra.ExactArgs(1),
-	Example: `  sem-ai deploy create staging --project my-app --url https://staging.example.com
-  sem-ai deploy create production --project my-app --branch main`,
+	Example: `  # tag-only release target, env var bound, auto-promote-only
+  sem-ai deploy create release --project sem-ai \
+    --tag-regex '^v[0-9].*' \
+    --subject-auto \
+    --env-var GITHUB_TOKEN=ghp_xxx
+
+  # main-branch-only snapshot target
+  sem-ai deploy create snapshot --project my-app --branch-exact main --subject-any`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.IsConfigured() {
 			return fmt.Errorf("not configured — run 'sem-ai connect' first")
 		}
-		projectID, err := resolveProjectID(deployCreateProjectFlag)
+		projectID, err := resolveProjectID(deployCreateSpec.projectFlag)
 		if err != nil {
 			output.Error("project_error", err.Error(), 1)
 			return err
 		}
-
-		body := map[string]any{
-			"project_id":  projectID,
-			"name":        args[0],
-			"description": deployCreateDescFlag,
-			"url":         deployCreateURLFlag,
+		body, err := deployCreateSpec.toBody(args[0])
+		if err != nil {
+			output.Error("flag_error", err.Error(), 2)
+			return err
 		}
-		if len(deployCreateBranchFlag) > 0 {
-			body["bookmark_parameter1"] = deployCreateBranchFlag[0]
+		body["project_id"] = projectID
+		token := deployCreateSpec.uniqueToken
+		if token == "" {
+			token = client.NewRequestToken()
 		}
+		body["unique_token"] = token
 
 		bodyBytes, _ := json.Marshal(body)
 		c := client.New()
@@ -229,12 +397,54 @@ var deployCreateCmd = &cobra.Command{
 	},
 }
 
+var deployUpdateSpec = &deployTargetSpec{}
+var deployUpdateNameFlag string
+
+var deployUpdateCmd = &cobra.Command{
+	Use:   "update <target-id>",
+	Short: "Update a deployment target (PATCH)",
+	Args:  cobra.ExactArgs(1),
+	Example: `  sem-ai deploy update <target-id> --tag-regex '^v[0-9]+\.[0-9]+\.[0-9]+$' --env-var GITHUB_TOKEN=new_value`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured — run 'sem-ai connect' first")
+		}
+		body, err := deployUpdateSpec.toBody(deployUpdateNameFlag)
+		if err != nil {
+			output.Error("flag_error", err.Error(), 2)
+			return err
+		}
+		token := deployUpdateSpec.uniqueToken
+		if token == "" {
+			token = client.NewRequestToken()
+		}
+		body["unique_token"] = token
+
+		bodyBytes, _ := json.Marshal(body)
+		c := client.New()
+		resp, err := c.Patch("deployment_targets", args[0], bodyBytes)
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		if resp.StatusCode != 200 {
+			output.Error("api_error", fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body)), resp.StatusCode)
+			return fmt.Errorf("API returned %d", resp.StatusCode)
+		}
+		var result any
+		json.Unmarshal(resp.Body, &result)
+		output.Result(result)
+		return nil
+	},
+}
+
 func init() {
 	deployTargetsCmd.Flags().StringVar(&deployTargetsProjectFlag, "project", "", "project name or ID (required)")
-	deployCreateCmd.Flags().StringVar(&deployCreateProjectFlag, "project", "", "project name or ID (required)")
-	deployCreateCmd.Flags().StringVar(&deployCreateDescFlag, "description", "", "target description")
-	deployCreateCmd.Flags().StringVar(&deployCreateURLFlag, "url", "", "target URL")
-	deployCreateCmd.Flags().StringArrayVar(&deployCreateBranchFlag, "branch", nil, "allowed branches")
+
+	bindDeploySpecFlags(deployCreateCmd, deployCreateSpec)
+
+	bindDeploySpecFlags(deployUpdateCmd, deployUpdateSpec)
+	deployUpdateCmd.Flags().StringVar(&deployUpdateNameFlag, "name", "", "rename the target")
 
 	deployCmd.AddCommand(deployTargetsCmd)
 	deployCmd.AddCommand(deployShowCmd)
@@ -242,6 +452,7 @@ func init() {
 	deployCmd.AddCommand(deployActivateCmd)
 	deployCmd.AddCommand(deployDeactivateCmd)
 	deployCmd.AddCommand(deployCreateCmd)
+	deployCmd.AddCommand(deployUpdateCmd)
 	deployCmd.AddCommand(deployDeleteCmd)
 	rootCmd.AddCommand(deployCmd)
 }


### PR DESCRIPTION
## Summary

`sem-ai deploy create` previously sent a thin body (`{project_id, name, description, url, bookmark_parameter1?}`) — missing the required `unique_token` field and all the things that turn a deployment target into a real promotion gate: `object_rules`, `subject_rules`, `env_vars`, `files`. The `--branch` flag also misused `bookmark_parameter1` (a deployment-history filter) as if it were a real branch restriction.

This PR brings `sem-ai deploy create` to full parity with the Semaphore `POST /api/v1alpha/deployment_targets` API, and adds the missing `deploy update` command.

## What changed (`cmd/deploy.go`)

- **Always send `unique_token`** — current code never sent it; the API rejects with HTTP 400.
- **`object_rules` flags** — `--tag-regex`, `--tag-exact`, `--branch-regex`, `--branch-exact`, `--allow-all-branches`, `--allow-all-tags`, `--allow-prs`. Each emits one entry with the appropriate `match_mode` (`ALL` / `EXACT` / `REGEX`). If no rule for a type is provided, that type is implicitly blocked — which is the right safe default for tag-only release targets.
- **`subject_rules` flags** — `--subject-any`, `--subject-user` (UUID auto-detected vs `git_login` string), `--subject-role` (repeatable), `--subject-auto`.
- **Secrets bound to the target** — `--env-var NAME=VALUE` (repeatable) and `--file PATH=LOCAL_SOURCE` (repeatable; reads the local file and base64-encodes the content).
- **Explicit bookmark params** — `--bookmark1/2/3`. The misleading `--branch` flag is dropped; old callers must move to `--branch-exact` (real restriction) or `--bookmark1` (history filter), depending on intent.
- **New `sem-ai deploy update <target-id>`** — PATCHes `/deployment_targets/:id` with the same flag surface as `create`. Only sent fields change; the rest is preserved server-side. `--name` renames.

## Skill update (`.agents/skills/deploy/SKILL.md`)

Updated to teach agents the new `create` / `update` surface — flag tables for object/subject rules, the implicit-block-when-no-rule semantics, the `--subject-auto` pattern for release targets, target-bound secrets vs project secrets, and the `deployment_target:` YAML reference for promotion gating.

## Verified end-to-end (against `skipi.semaphoreci.com/sem-ai`)

```sh
sem-ai deploy create release-test  --project sem-ai \\
  --tag-regex '^v[0-9].*' --subject-auto \\
  --description 'auto-promoted on v* tag only'

sem-ai deploy create snapshot-test --project sem-ai \\
  --branch-exact main --subject-any \\
  --env-var EXAMPLE=value --file /etc/x.conf=/tmp/source.txt

sem-ai deploy update <release-test-id> \\
  --tag-regex '^v[0-9]+\.[0-9]+\.[0-9]+\$' \\
  --description 'updated to stricter regex'

sem-ai deploy delete <id>            # cleanup
```

Negative paths return structured errors (missing `--project` → `project_error`; malformed `--env-var` → `flag_error`).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/...` passes
- [x] Live verify against skipi org (above)
- [x] CI: lint + tests run on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)