### PR TITLE
fix(version): synchronous refresh on cold/stale cache

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -143,16 +143,21 @@ var stderrIsTTY = func() bool {
 	return (info.Mode() & os.ModeCharDevice) != 0
 }
 
+// preRunCheckTimeout caps how long the PersistentPreRunE auto-notice will
+// wait for a cold-cache or stale-cache GitHub refresh. The cache absorbs
+// subsequent calls for 6h, so this cost is rare. Tight enough that an
+// offline user doesn't notice; loose enough to usually succeed.
+const preRunCheckTimeout = 1500 * time.Millisecond
+
 // maybeNotifyOnCommand is fired from rootCmd.PersistentPreRunE on every CLI
-// invocation. Best-effort, non-blocking, gated to avoid polluting scripts,
-// CI logs, and the version subcommand's own check path.
+// invocation. Gated to avoid polluting scripts, CI logs, and the version
+// subcommand's own check path.
 //
-// Behavior:
-//   - Cache fresh: synchronously evaluate notify-eligibility from cache, emit
-//     stderr notice if eligible, bump notified_for_version.
-//   - Cache stale or empty: spawn a background goroutine to refresh from
-//     GitHub. The current command returns immediately; the *next* command
-//     reads the refreshed cache. Never blocks foreground.
+// On cold or stale cache, performs a SYNCHRONOUS HTTP refresh with a tight
+// timeout (preRunCheckTimeout). Background goroutines don't survive short
+// CLI process lifetimes — the parent returns and the goroutine dies before
+// the HTTP call lands. After one successful refresh the cache absorbs calls
+// for 6h, so the sync-on-refresh cost is amortized.
 //
 // All gating is via shouldSkipPersistentCheck so tests can drive each lever.
 func maybeNotifyOnCommand(cmd *cobra.Command, stderr io.Writer) {
@@ -164,9 +169,17 @@ func maybeNotifyOnCommand(cmd *cobra.Command, stderr io.Writer) {
 	now := time.Now().UTC()
 
 	if !versioncheck.Fresh(state, now) {
-		// Stale or empty cache → background refresh. Do not notify this run.
-		go refreshCacheInBackground(now)
-		return
+		ctx, cancel := context.WithTimeout(context.Background(), preRunCheckTimeout)
+		defer cancel()
+		rel, err := versioncheck.Latest(ctx)
+		if err != nil {
+			return // offline / slow / rate-limited — try again next run
+		}
+		state.LastCheckedAt = now
+		state.LatestVersion = rel.Version
+		state.LatestPublishedAt = rel.PublishedAt
+		state.CurrentVersionWhenChecked = Version
+		_ = versioncheck.WriteCache(state)
 	}
 
 	if state.LatestVersion == "" {
@@ -205,26 +218,6 @@ func shouldSkipPersistentCheck(cmd *cobra.Command) bool {
 		return true
 	}
 	return false
-}
-
-// refreshCacheInBackground is the goroutine body for the stale-cache path.
-// 3s HTTP timeout; merges into a fresh ReadCache to avoid clobbering a
-// concurrent NotifiedForVersion bump.
-func refreshCacheInBackground(now time.Time) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	rel, err := versioncheck.Latest(ctx)
-	if err != nil {
-		return // silent on error; LastCheckedAt NOT bumped so we retry next run
-	}
-
-	current, _, _ := versioncheck.ReadCache()
-	current.LastCheckedAt = now
-	current.LatestVersion = rel.Version
-	current.LatestPublishedAt = rel.PublishedAt
-	current.CurrentVersionWhenChecked = Version
-	_ = versioncheck.WriteCache(current)
 }
 
 func init() {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -422,15 +422,18 @@ func TestMaybeNotifyOnCommand_FiresWhenEligible(t *testing.T) {
 	}
 }
 
-func TestMaybeNotifyOnCommand_StaleCache_SpawnsRefresh_NoSyncNotice(t *testing.T) {
+func TestMaybeNotifyOnCommand_StaleCache_SyncRefresh_ThenNotify(t *testing.T) {
 	_, calls := withGitHubMock(t, "0.4.1", 200)
 	forceTTYStderr(t, true)
 	t.Setenv("CI", "")
 
-	// Preseed STALE cache (12h old) with an older version.
+	// Preseed STALE cache (12h old) with an older version + already-notified
+	// for that older version. Refresh should overwrite latest → 0.4.1 →
+	// notice fires (we have not yet been notified for 0.4.1).
 	if err := versioncheck.WriteCache(versioncheck.CacheState{
-		LastCheckedAt: time.Now().UTC().Add(-12 * time.Hour),
-		LatestVersion: "0.3.5",
+		LastCheckedAt:      time.Now().UTC().Add(-12 * time.Hour),
+		LatestVersion:      "0.3.5",
+		NotifiedForVersion: "0.3.5",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -440,20 +443,12 @@ func TestMaybeNotifyOnCommand_StaleCache_SpawnsRefresh_NoSyncNotice(t *testing.T
 
 	buf := new(bytes.Buffer)
 	maybeNotifyOnCommand(makeCmd("status"), buf)
-	if buf.Len() != 0 {
-		t.Errorf("stale cache path should be silent this run; got:\n%s", buf.String())
-	}
 
-	// Wait briefly for goroutine to complete the refresh.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if atomic.LoadInt64(calls) >= 1 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
+	if got := atomic.LoadInt64(calls); got != 1 {
+		t.Errorf("HTTP calls = %d, want 1 (sync refresh on stale)", got)
 	}
-	if got := atomic.LoadInt64(calls); got < 1 {
-		t.Errorf("expected goroutine to make ≥1 HTTP call within 2s; got %d", got)
+	if !strings.Contains(buf.String(), "0.4.1") {
+		t.Errorf("expected notice for refreshed 0.4.1; got:\n%s", buf.String())
 	}
 
 	state, ok, _ := versioncheck.ReadCache()
@@ -462,6 +457,60 @@ func TestMaybeNotifyOnCommand_StaleCache_SpawnsRefresh_NoSyncNotice(t *testing.T
 	}
 	if state.LatestVersion != "0.4.1" {
 		t.Errorf("cache LatestVersion after refresh = %q, want 0.4.1", state.LatestVersion)
+	}
+	if state.NotifiedForVersion != "0.4.1" {
+		t.Errorf("NotifiedForVersion = %q, want 0.4.1", state.NotifiedForVersion)
+	}
+}
+
+func TestMaybeNotifyOnCommand_ColdCache_SyncRefresh_ThenNotify(t *testing.T) {
+	_, calls := withGitHubMock(t, "0.4.1", 200)
+	forceTTYStderr(t, true)
+	t.Setenv("CI", "")
+	// No preseeded cache.
+
+	oldV := Version
+	Version = "0.3.0"
+	t.Cleanup(func() { Version = oldV })
+
+	buf := new(bytes.Buffer)
+	maybeNotifyOnCommand(makeCmd("status"), buf)
+
+	if got := atomic.LoadInt64(calls); got != 1 {
+		t.Errorf("HTTP calls = %d, want 1 (sync refresh on cold)", got)
+	}
+	if !strings.Contains(buf.String(), "0.4.1") {
+		t.Errorf("expected first-run notice; got:\n%s", buf.String())
+	}
+
+	state, ok, _ := versioncheck.ReadCache()
+	if !ok {
+		t.Fatal("cache should have been written on cold-refresh")
+	}
+	if state.LatestVersion != "0.4.1" {
+		t.Errorf("LatestVersion = %q, want 0.4.1", state.LatestVersion)
+	}
+}
+
+func TestMaybeNotifyOnCommand_NetworkFailure_Silent_NoCacheBump(t *testing.T) {
+	_, _ = withGitHubMock(t, "", 503)
+	forceTTYStderr(t, true)
+	t.Setenv("CI", "")
+
+	// Cold cache.
+	oldV := Version
+	Version = "0.3.0"
+	t.Cleanup(func() { Version = oldV })
+
+	buf := new(bytes.Buffer)
+	maybeNotifyOnCommand(makeCmd("status"), buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected silence on network failure with cold cache; got:\n%s", buf.String())
+	}
+	_, ok, _ := versioncheck.ReadCache()
+	if ok {
+		t.Error("cache should not be written on network failure")
 	}
 }
 


### PR DESCRIPTION
## Summary

The auto-notice goroutine in `rootCmd.PersistentPreRunE` never survived process exit on short-lived CLI commands — cache stayed cold forever and the notice never fired on first-ever runs. Replace with synchronous HTTP using a tight 1.5s timeout.

## The bug

`maybeNotifyOnCommand` on cold/stale cache spawned a goroutine:

```go
if !versioncheck.Fresh(state, now) {
    go refreshCacheInBackground(now)
    return
}
```

But CLI commands like `sem-ai discover` finish in ~50ms — well before the goroutine's HTTP call (3s timeout) lands. Go's runtime tears down all goroutines when `main()` returns, so:

1. Run 1: cold cache → spawn goroutine → return immediately → process exits → goroutine dies → cache never written
2. Run 2: cache still cold → same thing → no notice ever fires

Confirmed empirically: after a fresh `discover` against an empty `$XDG_CACHE_HOME`, the cache directory is not created.

## The fix

Synchronous HTTP with a tight 1500ms timeout on cold/stale cache. After one successful refresh, the 6h freshness gate absorbs subsequent calls — so the sync cost is paid at most once per 6h per user.

```
cold cache (first ever):    sync HTTP ≤1.5s, then notify in same run
stale-with-data (>6h old):  sync HTTP ≤1.5s, then notify with refreshed data
fresh cache:                no HTTP, fast notify path
```

Offline / slow / rate-limited users get silent fallback (cache stays cold; retry next run). Same trade `gh` and `npm-update-notifier` make for the same reason — short-lived processes can't use background workers reliably.

## Verification

Cold-cache smoke under a real PTY:
```
$ XDG_CACHE_HOME=/tmp/fresh sem-ai discover
sem-ai 0.0.2 is available (you have 0.0.1). Upgrade:
  curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh
{ ...discover output... }

$ ls /tmp/fresh/sem-ai/
version-check.json    # ← cache written, didn't happen before

$ sem-ai discover    # second run
{ ...discover output... }    # silent (notified)
```

## Test plan

- [x] `go test ./cmd/...` — 20 tests pass; two new (`ColdCache_SyncRefresh_ThenNotify`, `NetworkFailure_Silent_NoCacheBump`); one renamed (`StaleCache_SyncRefresh_ThenNotify`) with corrected expectations.
- [x] `go test ./pkg/versioncheck/...` — 21 tests pass unchanged.
- [x] `go vet ./...` clean.
- [x] Cold-cache + PTY smoke fires notice correctly; cache file appears.
- [x] Re-run after notice is silent (notified_for_version bumped).
- [x] Offline simulation (503 from mock) → silent, cache untouched.

## Trade-off

First-ever run (and one run every 6h after that) adds up to ~1.5s of latency. After that, every command is sub-millisecond. Acceptable — most popular CLIs that do update checks land on the same trade.

If a user finds even 1.5s objectionable, `SEM_AI_NO_UPDATE_CHECK=1` skips the check entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)