### PR TITLE
feat(version): nag on every command (stderr only)

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -93,8 +93,9 @@ func runCheckVerbose(ctx context.Context) error {
 }
 
 // runNotifyOnlyIfNewer is the hook-friendly mode. Silent unless a newer
-// release exists AND the user hasn't been notified for that release yet.
-// Output goes to stderr (surfaces in chat as developer context).
+// release exists. Output goes to stderr (stdout JSON contract preserved
+// for callers piping --format json to jq / agents). Notice fires every
+// invocation while behind — single nag-on-disk state would just stale.
 func runNotifyOnlyIfNewer(ctx context.Context, stderr io.Writer) error {
 	if versioncheck.EnvOptOut() {
 		return nil
@@ -122,15 +123,9 @@ func runNotifyOnlyIfNewer(ctx context.Context, stderr io.Writer) error {
 	if !newer {
 		return nil
 	}
-	if state.NotifiedForVersion == state.LatestVersion {
-		return nil
-	}
 
 	fmt.Fprintf(stderr, "sem-ai %s is available (you have %s). Upgrade:\n  %s\n",
 		state.LatestVersion, Version, upgradeHint)
-
-	state.NotifiedForVersion = state.LatestVersion
-	_ = versioncheck.WriteCache(state) // best-effort; failure non-fatal
 	return nil
 }
 
@@ -190,15 +185,9 @@ func maybeNotifyOnCommand(cmd *cobra.Command, stderr io.Writer) {
 	if !newer {
 		return
 	}
-	if state.NotifiedForVersion == state.LatestVersion {
-		return
-	}
 
 	fmt.Fprintf(stderr, "sem-ai %s is available (you have %s). Upgrade:\n  %s\n",
 		state.LatestVersion, Version, upgradeHint)
-
-	state.NotifiedForVersion = state.LatestVersion
-	_ = versioncheck.WriteCache(state) // best-effort
 }
 
 // shouldSkipPersistentCheck encapsulates every gating decision so tests can

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -130,13 +130,14 @@ func TestRunNotifyOnlyIfNewer_ColdCacheNewer_PrintsOnce(t *testing.T) {
 		t.Errorf("notice missing install.sh hint; got:\n%s", out)
 	}
 
-	// Second call: still newer, but already notified → silent.
+	// Second call: still newer → notice fires again (always-on stderr nag
+	// by design; stdout JSON contract preserved for agents).
 	buf.Reset()
 	if err := runNotifyOnlyIfNewer(context.Background(), buf); err != nil {
 		t.Fatal(err)
 	}
-	if buf.Len() != 0 {
-		t.Errorf("second call should be silent (notified); got:\n%s", buf.String())
+	if !strings.Contains(buf.String(), "0.4.1") {
+		t.Errorf("second call should also nag; got:\n%s", buf.String())
 	}
 }
 
@@ -414,11 +415,12 @@ func TestMaybeNotifyOnCommand_FiresWhenEligible(t *testing.T) {
 		t.Errorf("HTTP calls = %d, want 0 (fresh cache)", got)
 	}
 
-	// Second call: notified_for_version bumped → silent.
+	// Second call: still newer → notice fires AGAIN (every command nags
+	// on stderr while behind; stdout JSON unaffected so agents parse cleanly).
 	buf.Reset()
 	maybeNotifyOnCommand(makeCmd("status"), buf)
-	if buf.Len() != 0 {
-		t.Errorf("second call should be silent; got:\n%s", buf.String())
+	if !strings.Contains(buf.String(), "0.4.1") {
+		t.Errorf("second call should also nag; got:\n%s", buf.String())
 	}
 }
 
@@ -427,13 +429,11 @@ func TestMaybeNotifyOnCommand_StaleCache_SyncRefresh_ThenNotify(t *testing.T) {
 	forceTTYStderr(t, true)
 	t.Setenv("CI", "")
 
-	// Preseed STALE cache (12h old) with an older version + already-notified
-	// for that older version. Refresh should overwrite latest → 0.4.1 →
-	// notice fires (we have not yet been notified for 0.4.1).
+	// Preseed STALE cache (12h old) with an older version. Sync refresh
+	// should overwrite latest → 0.4.1 → notice fires.
 	if err := versioncheck.WriteCache(versioncheck.CacheState{
-		LastCheckedAt:      time.Now().UTC().Add(-12 * time.Hour),
-		LatestVersion:      "0.3.5",
-		NotifiedForVersion: "0.3.5",
+		LastCheckedAt: time.Now().UTC().Add(-12 * time.Hour),
+		LatestVersion: "0.3.5",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -457,9 +457,6 @@ func TestMaybeNotifyOnCommand_StaleCache_SyncRefresh_ThenNotify(t *testing.T) {
 	}
 	if state.LatestVersion != "0.4.1" {
 		t.Errorf("cache LatestVersion after refresh = %q, want 0.4.1", state.LatestVersion)
-	}
-	if state.NotifiedForVersion != "0.4.1" {
-		t.Errorf("NotifiedForVersion = %q, want 0.4.1", state.NotifiedForVersion)
 	}
 }
 

--- a/pkg/versioncheck/cache.go
+++ b/pkg/versioncheck/cache.go
@@ -17,13 +17,15 @@ const CacheSchemaVersion = 1
 const DefaultTTL = 6 * time.Hour
 
 // CacheState is the on-disk shape of ~/.cache/sem-ai/version-check.json.
+// Old cache files may contain a `notified_for_version` field — it is silently
+// ignored on read (encoding/json discards unknown fields) and not written on
+// updates. The notice is now stderr-on-every-command by design.
 type CacheState struct {
 	Schema                    int       `json:"schema"`
 	LastCheckedAt             time.Time `json:"last_checked_at"`
 	LatestVersion             string    `json:"latest_version,omitempty"`
 	LatestPublishedAt         time.Time `json:"latest_published_at,omitempty"`
 	CurrentVersionWhenChecked string    `json:"current_version_when_checked,omitempty"`
-	NotifiedForVersion        string    `json:"notified_for_version,omitempty"`
 }
 
 // CachePath returns the location of the cache file. Honors XDG_CACHE_HOME;

--- a/pkg/versioncheck/cache_test.go
+++ b/pkg/versioncheck/cache_test.go
@@ -43,7 +43,6 @@ func TestReadWriteRoundTrip(t *testing.T) {
 		LatestVersion:             "0.4.1",
 		LatestPublishedAt:         now.Add(-time.Hour),
 		CurrentVersionWhenChecked: "0.3.0",
-		NotifiedForVersion:        "0.4.1",
 	}
 
 	if err := WriteCache(state); err != nil {


### PR DESCRIPTION
## Summary

Update notice now fires every CLI invocation while behind a release, not just once per (current, latest) pair. Stderr only — stdout JSON contract preserved so agents and scripts parsing `sem-ai foo --format json | jq` see no extra noise.

## Why

The previous "once per new version" suppression (via `notified_for_version` in cache) was supposed to avoid spamming interactive users. In practice users saw the nag once, missed it in scrollback, then forgot. Always-on stderr is a stronger persistent signal without polluting machine-readable output.

Three opt-outs already cover the cases where always-on would be wrong:

- **Agents / scripts** parsing stdout JSON: stderr is separate, no impact.
- **Non-interactive runs** (CI, scripted, redirected stderr): non-TTY-stderr gate suppresses.
- **Users who actively don't want it**: `SEM_AI_NO_UPDATE_CHECK=1` env.

## Diff

```diff
- if state.NotifiedForVersion == state.LatestVersion {
-     return
- }
  fmt.Fprintf(stderr, "sem-ai %s is available (you have %s). Upgrade:\n  %s\n", ...)
- state.NotifiedForVersion = state.LatestVersion
- _ = versioncheck.WriteCache(state)
```

Applied to both `maybeNotifyOnCommand` (PersistentPreRunE auto path) and `runNotifyOnlyIfNewer` (explicit verb / plugin hook target).

The `NotifiedForVersion` field is removed from `CacheState`. Old cache files that have it still parse fine — `encoding/json` silently discards unknown fields.

## Smoke (PTY, against latest v0.0.3 with binary stamped 0.0.1)

```
run 1:
  sem-ai 0.0.3 is available (you have 0.0.1). Upgrade: ...
run 2:
  sem-ai 0.0.3 is available (you have 0.0.1). Upgrade: ...
run 3:
  sem-ai 0.0.3 is available (you have 0.0.1). Upgrade: ...

stdout JSON pipe-test:
  { "commands": [ ... ] }   # clean, no noise
```

## Test plan

- [x] `go test ./...` — 39 tests pass; ColdCacheNewer_PrintsOnce + MaybeNotify_FiresWhenEligible now assert second call ALSO nags
- [x] `go vet ./...` clean
- [x] PTY smoke: notice fires on every consecutive command
- [x] Pipe smoke: `2>/dev/null` cleans stderr, stdout JSON unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)