### PR TITLE
fix(plugin): hooks.json schema (top-level hooks wrapper)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,7 +11,7 @@
         "path": "../../assets/plugin"
       },
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.0.5"
+      "version": "0.1.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.0.5"
+      "version": "0.1.1"
     }
   ]
 }

--- a/assets/plugin/hooks/hooks.json
+++ b/assets/plugin/hooks/hooks.json
@@ -1,13 +1,16 @@
 {
-  "SessionStart": [
-    {
-      "hooks": [
-        {
-          "type": "command",
-          "command": "sem-ai version --check --notify-only-if-newer",
-          "timeout": 4
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sem-ai version --check --notify-only-if-newer",
+            "timeout": 4
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.0.5",
+  "version": "0.1.1",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {


### PR DESCRIPTION
## Summary

Real Claude Code install of v0.1.0's plugin rejected `hooks/hooks.json`:

```
Failed to load hooks from .../sem-ai/0.1.0/hooks/hooks.json: [
  { "expected": "record", "code": "invalid_type",
    "path": ["hooks"], "message": "expected record, received undefined" }
]
```

Claude Code's hooks file uses the **same schema as settings.json**: a top-level `hooks` record, with event names as keys.

## Fix

```diff
 {
+  "hooks": {
     "SessionStart": [
       {
+        "matcher": "*",
         "hooks": [
           { "type": "command", "command": "sem-ai version --check --notify-only-if-newer", "timeout": 4 }
         ]
       }
     ]
+  }
 }
```

Two changes:
1. Wrapped event keys under a top-level `hooks: {}` record.
2. Added `matcher: "*"` to the event entry (required by Claude Code's schema).

## Version bumps

- `assets/plugin/plugin.json`: 0.1.0 → 0.1.1
- `.claude-plugin/marketplace.json`: 0.1.0 → 0.1.1
- `.agents/plugins/marketplace.json`: 0.1.0 → 0.1.1

## Out of scope (separate decision)

The same install also logged:

> MCP server "sem-ai" skipped — same command/URL as already-configured "semaphore"

The plugin's `mcpServers["sem-ai"]` collides with a user's pre-existing `mcpServers["semaphore"]` (both running `sem-ai mcp`). The plugin install respects the existing config and skips. Not a bug — informational. Renaming the plugin's MCP key is a separate decision and doesn't block this fix.

## Test plan

- [x] `jq .` validates each modified JSON
- [ ] Manual: install v0.1.1 plugin in real Claude Code session — hooks load cleanly (no `[invalid_type]` error); SessionStart fires; chat shows version-check output if behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)