### PR TITLE
feat(plugin): preflight binary check + bootstrap skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,7 +11,7 @@
         "path": "../../assets/plugin"
       },
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.1"
+      "version": "0.1.2"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.1"
+      "version": "0.1.2"
     }
   ]
 }

--- a/assets/plugin/hooks/hooks.json
+++ b/assets/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sem-ai version --check --notify-only-if-newer",
+            "command": "command -v sem-ai >/dev/null 2>&1 && sem-ai version --check --notify-only-if-newer || printf 'sem-ai binary not found on PATH. Install:\\n  curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh\\n' >&2",
             "timeout": 4
           }
         ]

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {

--- a/assets/plugin/skills/sem-ai-bootstrap/SKILL.md
+++ b/assets/plugin/skills/sem-ai-bootstrap/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: sem-ai-bootstrap
+description: Diagnose sem-ai plugin issues when the sem-ai binary isn't installed yet, and guide the user through binary install.
+trigger: user reports sem-ai not working, MCP tools missing, slash command not found, sem-ai connect failing, or sees "command not found: sem-ai"
+---
+
+# sem-ai bootstrap
+
+The sem-ai plugin's MCP server, slash commands, and SessionStart update-check
+hook all call the `sem-ai` Go binary. The plugin bundles only the manifest +
+skills + slash-command markdown — the binary lives outside the plugin and
+must be installed separately.
+
+## When this skill applies
+
+The user has installed the sem-ai plugin (via `/plugin install sem-ai@semaphoreio`)
+but is hitting one of:
+
+- "command not found: sem-ai"
+- MCP server "sem-ai" failed to start
+- The SessionStart hook printed `sem-ai binary not found on PATH. Install: ...`
+- Slash commands appear listed but error on run
+
+## What to tell the user
+
+Install the binary:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh
+```
+
+After install, they may need to add `$HOME/.local/bin` (or `$HOME/.semaphore-ai/bin`)
+to their PATH — install.sh prints a hint on stderr when that's needed.
+
+Then:
+
+```sh
+sem-ai connect <your-org>.semaphoreci.com <your-api-token>
+```
+
+Token is found at `https://me.semaphoreci.com/account`.
+
+After binary install + token bootstrap, restart their AI host session (or
+reload the plugin) so the MCP server picks up the now-working binary.
+
+## When this skill does NOT apply
+
+If the user can already run `sem-ai version` from their shell, the binary
+is installed. The issue is elsewhere — likely token / network / org context.
+Direct them to `sem-ai context list` and `sem-ai diagnose` instead.


### PR DESCRIPTION
## Summary

If a user installs the sem-ai plugin BEFORE running `install.sh` to get the binary, every plugin primitive that calls `sem-ai` silently fails: MCP server doesn't register, slash commands error, SessionStart hook fails. The host doesn't surface why.

This PR adds two layers of guidance so first-time users get an in-chat install hint within seconds of opening their session — no README required.

## Two layers

### 1. SessionStart hook preflight (active)

Hook command short-circuits on missing binary:

```sh
command -v sem-ai >/dev/null 2>&1 \
  && sem-ai version --check --notify-only-if-newer \
  || printf 'sem-ai binary not found on PATH. Install:\n  curl -fsSL .../install.sh | sh\n' >&2
```

Exits 0 either way (fail-open). When binary IS present, behavior is unchanged from v0.1.1.

### 2. `sem-ai-bootstrap` skill (passive)

New skill the agent reads as context. Triggers when user mentions:
- "command not found: sem-ai"
- MCP server not working
- Slash command erroring
- `sem-ai connect` failing

Walks them through:
1. Install binary via `install.sh`
2. `sem-ai connect <host> <token>`
3. Restart session / reload plugin

Self-deprecating: skill explicitly says "if user can already run `sem-ai version` from shell, this skill does NOT apply — diagnose elsewhere."

## Combined behavior

| User state | What they see |
|---|---|
| Binary present, on latest | Silent (notice suppression for current version) |
| Binary present, update available | Two-line stderr notice in chat (existing behavior) |
| Binary missing, plugin installed | Two-line install hint in chat (NEW) |
| User asks "why isn't sem-ai working?" | Agent reads bootstrap skill and walks them through install (NEW) |

## Version bumps

- `assets/plugin/plugin.json`: 0.1.1 → 0.1.2
- `.claude-plugin/marketplace.json`: 0.1.1 → 0.1.2
- `.agents/plugins/marketplace.json`: 0.1.1 → 0.1.2

## Test plan

- [x] `jq .` validates all four JSON files
- [x] SKILL.md frontmatter parses (well-formed YAML)
- [ ] Manual: in a Claude Code session WITHOUT `sem-ai` on PATH, install plugin and open new session — verify the install hint appears as developer context
- [ ] Manual: with `sem-ai` on PATH, install plugin and open new session — verify version-check runs as v0.1.1 (no install hint, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)