### PR TITLE
feat(plugin): autoUpdate by default in marketplace

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -4,6 +4,7 @@
     "name": "Semaphore CI",
     "url": "https://semaphoreci.com"
   },
+  "autoUpdate": true,
   "plugins": [
     {
       "name": "sem-ai",
@@ -11,7 +12,7 @@
         "path": "../../assets/plugin"
       },
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.2"
+      "version": "0.1.3"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,12 +4,13 @@
     "name": "Semaphore CI",
     "url": "https://semaphoreci.com"
   },
+  "autoUpdate": true,
   "plugins": [
     {
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.2"
+      "version": "0.1.3"
     }
   ]
 }

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {


### PR DESCRIPTION
## Summary

Sets `autoUpdate: true` at the marketplace manifest level so users who run `/plugin marketplace add semaphoreio/sem-ai` automatically opt into auto-updates.

## Why

Verified empirically against my own install: when `autoUpdate: true` was set on the `semaphoreio` entry in `~/.claude/plugins/known_marketplaces.json`, Claude Code pulled v0.1.2 within ~2 minutes of the tag landing — no manual `/plugin update` needed.

Setting this in the marketplace.json itself propagates the same behavior to every future installer without them having to flip the flag manually. sem-ai iterates fast; auto-update is the right default.

## Changes

```diff
 {
   "name": "semaphoreio",
   "owner": {...},
+  "autoUpdate": true,
   "plugins": [...]
 }
```

Applied to both `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`.

Plugin + marketplace versions bumped to 0.1.3.

## Risk

Low — plugin contents are JSON manifests + markdown skills + a SessionStart hook that's idempotent and already failure-tolerant (binary preflight from v0.1.2). No executable code runs on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)