### PR TITLE
ci: parallelize Build snapshot with Quality + Security

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -62,7 +62,7 @@ blocks:
             - docker run --rm -v "$(pwd):/workspace" -v /tmp/junit.tpl:/tmp/junit.tpl -w /workspace aquasec/trivy:0.70.0 fs --scanners vuln,secret,misconfig --severity HIGH,CRITICAL --exit-code 1 --format template --template '@/tmp/junit.tpl' --output junit-trivy.xml .
 
   - name: Build snapshot
-    dependencies: [Quality, Security]
+    dependencies: []
     task:
       jobs:
         - name: GoReleaser snapshot


### PR DESCRIPTION
## Summary

Removes the `dependencies: [Quality, Security]` gate from the Build snapshot block. All three top-level blocks now run in parallel.

```diff
   - name: Build snapshot
-    dependencies: [Quality, Security]
+    dependencies: []
```

## Why

Build snapshot was waiting for Quality + Security to pass before starting. That serialization wasn't buying anything: failing-quality builds still fail loud (Quality block goes red, branch protection blocks merge). The cross-compile validation that Build snapshot performs is orthogonal to lint / test / vuln-scan — running them in parallel is the natural shape.

Expected wall-clock improvement: ~30s on warm-cache runs (Build snapshot's setup phase overlaps with Quality's tests); larger on cold-cache runs where Build snapshot's GoReleaser fetch can overlap with the test compile-cache build.

## Safety

- Branch protection still requires the full pipeline green before merge — broken-quality code can't ship.
- Publish snapshot promotion (the artifact-push step) still depends on the full pipeline being green — host-side gating is unaffected.
- Publish GitHub Release promotion (tag-triggered) is unchanged.

## Test plan

- [x] `sem-ai yaml validate --file .semaphore/semaphore.yml` returns valid
- [ ] Push triggers CI; verify all 3 blocks start in parallel + complete; total wall-clock shorter than recent baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)