### PR TITLE
ci: drop auto_promote on snapshot publish

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -79,8 +79,6 @@ promotions:
   - name: Publish snapshot
     pipeline_file: snapshot.yml
     deployment_target: snapshot
-    auto_promote:
-      when: "branch = 'main' AND result = 'passed'"
 
   - name: Publish GitHub Release
     pipeline_file: release.yml


### PR DESCRIPTION
## Summary

- Removes the auto_promote block on the **Publish snapshot** promotion so it no longer fires on every passing main build.
- Promotion remains available as a manual click in the Semaphore UI for when a snapshot artifact is genuinely wanted.
- Tag-based **Publish GitHub Release** auto-promote (`tag =~ '^v.*'`) is unchanged.

## Test plan

- [ ] After merge: confirm next main build does not auto-promote
- [ ] Confirm next `v*` tag still auto-promotes the release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)