### PR TITLE
chore(release): add `make release VERSION=X.Y.Z` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DATE      := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS   := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 INSTALL   := /usr/local/bin
 
-.PHONY: build install uninstall clean test fmt vet
+.PHONY: build install uninstall clean test fmt vet release
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -29,3 +29,23 @@ fmt:
 
 vet:
 	go vet ./...
+
+# Bump plugin manifests, commit, and tag a new release.
+#   Usage: make release VERSION=0.1.8
+# Does NOT push — review locally, then run the printed git push commands.
+release:
+	@test -n "$(VERSION)" || (echo "ERROR: VERSION required (e.g. make release VERSION=0.1.8)" && exit 1)
+	@echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' || (echo "ERROR: VERSION must match X.Y.Z (got '$(VERSION)')" && exit 1)
+	@command -v yq >/dev/null 2>&1 || (echo "ERROR: yq required (brew install yq)" && exit 1)
+	@test -z "$$(git status --porcelain)" || (echo "ERROR: working tree dirty — commit or stash first" && exit 1)
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || (echo "ERROR: must run on main branch (currently on $$(git rev-parse --abbrev-ref HEAD))" && exit 1)
+	@test -z "$$(git tag -l v$(VERSION))" || (echo "ERROR: tag v$(VERSION) already exists locally" && exit 1)
+	yq -i -o json '.plugins[0].version = "$(VERSION)"' .claude-plugin/marketplace.json
+	yq -i -o json '.version = "$(VERSION)"' assets/plugin/plugin.json
+	@git --no-pager diff --stat .claude-plugin/marketplace.json assets/plugin/plugin.json
+	git add .claude-plugin/marketplace.json assets/plugin/plugin.json
+	git commit -m "chore(release): bump plugin manifests to v$(VERSION)"
+	git tag -a v$(VERSION) -m "v$(VERSION)"
+	@echo ""
+	@echo "Bumped + committed + tagged v$(VERSION) locally. To publish:"
+	@echo "  git push origin main && git push origin v$(VERSION)"


### PR DESCRIPTION
## Summary

- New \`make release VERSION=X.Y.Z\` target bumps both \`.claude-plugin/marketplace.json\` and \`assets/plugin/plugin.json\`, commits the bump, and tags \`v<VERSION>\` locally.
- Does NOT push — prints the push commands instead so release is gated on a deliberate human action.
- Guards: VERSION must match X.Y.Z, \`yq\` must be installed, working tree must be clean, branch must be \`main\`, tag must not already exist.

## Why

Manifests were never bumped on v0.1.6 (\`sem-ai project create\`) or v0.1.7 (\`gha-to-semaphore\` skill). Claude Code reads \`.claude-plugin/marketplace.json\` to decide if there's a new plugin version, so it kept showing 0.1.5 as latest and never notified users about new skills. This adds a one-command tool so the bump can't get forgotten on the next release.

## Test plan

- [x] \`make release\` with no VERSION → fails with clear message
- [x] \`make release VERSION=bogus\` → regex guard rejects
- [x] \`make release VERSION=0.1.8\` on dirty tree → bails before any change
- [ ] Manual run on clean main once this PR merges → produces correct bump commit + annotated tag

## Follow-up

Immediately after this PR merges: run \`make release VERSION=0.1.8\` on main to sync the manifests with the already-shipped v0.1.7 binaries (and bump to .8 so Claude detects the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)