### PR TITLE
refactor(skills): conform frontmatter to Agent Skills spec

### DIFF
--- a/assets/plugin/skills/gha-to-semaphore/SKILL.md
+++ b/assets/plugin/skills/gha-to-semaphore/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: gha-to-semaphore
-description: Translate a repo's GitHub Actions workflows into an equivalent Semaphore pipeline. This skill is ONLY about the GHA→Semaphore mapping and the conversion procedure. For Semaphore-side depth (cache CLI, test-results, blocks structure, sharding, promotions) defer to the linked skills.
-trigger: user asks to convert/port/migrate GitHub Actions to Semaphore, "translate this workflow", "set up Semaphore CI for this repo with the GHA workflows", "convert ci.yml", or repo has `.github/workflows/` and the user wants Semaphore instead
+description: Translate a repo's GitHub Actions workflows into an equivalent Semaphore pipeline. ONLY covers the GHA→Semaphore mapping and conversion procedure; for Semaphore-side depth (cache CLI, test-results, blocks structure, sharding, promotions) defer to the linked skills. Use when the user asks to convert/port/migrate GitHub Actions to Semaphore, says "translate this workflow" or "convert ci.yml", or the repo has `.github/workflows/` and the user wants Semaphore instead.
 ---
 
 # Convert GitHub Actions to a Semaphore pipeline

--- a/assets/plugin/skills/probe-agent-environment/SKILL.md
+++ b/assets/plugin/skills/probe-agent-environment/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: probe-agent-environment
-description: Spin up a short-lived Semaphore testbox to check what's actually installed on an agent — tools, versions, toolbox functions, runtimes — when the official image docs don't answer the question.
-trigger: agent needs to confirm whether a tool/runtime/version is preinstalled on a Semaphore agent; questions like "does the runner have X", "what version of Y ships on ubuntu2204/ubuntu2404", "is jq/yq/gh/aws/etc on the path", "what toolbox functions exist"; before writing a CI step that installs a tool, verify it isn't already preinstalled
+description: Spin up a short-lived Semaphore testbox to check what's actually installed on an agent — tools, versions, toolbox functions, runtimes — when the official image docs don't answer the question. Use when an agent needs to confirm whether a tool/runtime/version is preinstalled on a Semaphore agent ("does the runner have X", "what version of Y ships on ubuntu2204/ubuntu2404", "is jq/yq/gh/aws on PATH", "what toolbox functions exist"), or before adding a CI step that installs a tool — verify it isn't already preinstalled.
 ---
 
 # Probe a Semaphore agent with a testbox

--- a/assets/plugin/skills/sem-ai-bootstrap/SKILL.md
+++ b/assets/plugin/skills/sem-ai-bootstrap/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: sem-ai-bootstrap
-description: Diagnose sem-ai plugin issues when the sem-ai binary isn't installed yet, and guide the user through binary install.
-trigger: user reports sem-ai not working, MCP tools missing, slash command not found, sem-ai connect failing, or sees "command not found: sem-ai"
+description: Diagnose sem-ai plugin issues when the sem-ai binary isn't installed yet, and guide the user through binary install. Use when the user reports sem-ai not working, MCP tools missing, slash command not found, `sem-ai connect` failing, or sees "command not found: sem-ai".
 ---
 
 # sem-ai bootstrap

--- a/assets/plugin/skills/semaphore-blocks/SKILL.md
+++ b/assets/plugin/skills/semaphore-blocks/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: semaphore-blocks
-description: Explain how Semaphore pipelines are structured — blocks, tasks, jobs, dependencies, parallelism — and link to sem-ai commands for inspecting them.
-trigger: user asks about Semaphore pipeline structure, blocks, tasks, jobs, parallelism, dependencies, fan-out / fan-in, why a job is waiting, how to split work into parallel blocks, where to put agent / prologue / epilogue / secrets / env_vars
+description: Explain how Semaphore pipelines are structured — blocks, tasks, jobs, dependencies, parallelism — and link to sem-ai commands for inspecting them. Use when the user asks about Semaphore pipeline structure, blocks, tasks, jobs, parallelism, dependencies, fan-out / fan-in, why a job is waiting, how to split work into parallel blocks, or where to put agent / prologue / epilogue / secrets / env_vars.
 ---
 
 # Semaphore blocks, tasks, and jobs

--- a/assets/plugin/skills/semaphore-ci/SKILL.md
+++ b/assets/plugin/skills/semaphore-ci/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: semaphore-ci
-description: Manage Semaphore CI/CD via sem-ai. Use when the user asks about CI status, pipeline failures, test results, deployments, secrets, or anything related to their Semaphore pipelines and workflows.
-when_to_use: >
-  Trigger on: "CI status", "pipeline failed", "why did CI fail", "test results",
-  "deploy to staging", "rerun the pipeline", "what's flaky", "check the build",
-  "show me the logs", "promote to production", "secrets", "notifications",
-  "scheduled tasks", "deployment targets", "validate yaml", "project health"
+description: Manage Semaphore CI/CD via sem-ai. Use when the user asks about CI status, pipeline failures, test results, deployments, secrets, notifications, scheduled tasks, deployment targets, project health, or anything related to their Semaphore pipelines and workflows — e.g. "CI status", "pipeline failed", "why did CI fail", "deploy to staging", "rerun the pipeline", "what's flaky", "check the build", "show me the logs", "promote to production", "validate yaml".
 allowed-tools: Bash(sem-ai *)
 ---
 

--- a/assets/plugin/skills/semaphore-promotions/SKILL.md
+++ b/assets/plugin/skills/semaphore-promotions/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: semaphore-promotions
-description: Explain Semaphore promotions — chained pipelines for deploys, gates, and environment fan-out — and link to sem-ai commands for triggering and inspecting them.
-trigger: user asks about Semaphore promotions, deploys, deployment targets, auto-promote, parameterized promotions, staging vs production gates, how to chain pipelines, environment fan-out
+description: Explain Semaphore promotions — chained pipelines for deploys, gates, and environment fan-out — and link to sem-ai commands for triggering and inspecting them. Use when the user asks about Semaphore promotions, deploys, deployment targets, auto-promote, parameterized promotions, staging vs production gates, how to chain pipelines, or environment fan-out.
 ---
 
 # Semaphore promotions

--- a/assets/plugin/skills/semaphore-test-results/SKILL.md
+++ b/assets/plugin/skills/semaphore-test-results/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: semaphore-test-results
-description: Publish JUnit test reports from Semaphore jobs and surface them in the UI's Test Reports tab. Covers the `test-results` CLI, why it must live in `epilogue` (not the test command itself), and per-framework JUnit configuration for Go, pytest, RSpec, Jest, Vitest, ExUnit, Java.
-trigger: pipeline writes JUnit / test reports; questions about Test Reports tab; "why don't I see test results in Semaphore"; failures publish silently; flaky test surfacing; per-framework JUnit setup; pipeline-level aggregated report; `test-results publish` / `test-results gen-pipeline-report`
+description: Publish JUnit test reports from Semaphore jobs and surface them in the UI's Test Reports tab. Covers the `test-results` CLI, why it must live in `epilogue` (not the test command itself), and per-framework JUnit configuration for Go, pytest, RSpec, Jest, Vitest, ExUnit, Java. Use when a pipeline writes JUnit / test reports, the Test Reports tab is empty after a failure, failures publish silently, the user asks about flaky test surfacing or per-framework JUnit setup, or any time `test-results publish` / `test-results gen-pipeline-report` is involved.
 ---
 
 # Publishing test results on Semaphore

--- a/assets/plugin/skills/semaphore-toolbox/SKILL.md
+++ b/assets/plugin/skills/semaphore-toolbox/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: semaphore-toolbox
-description: The Semaphore toolbox — CLIs preinstalled in every job for caching, artifacts, language version switching, services, retries, and SSH debugging. Authoritative reference for the cache / artifact / retry / sem-version / sem-service / checkout commands.
-trigger: agent needs to use or reason about Semaphore toolbox commands; questions about cache CLI semantics, artifact push/pull, sem-version, sem-service, retry, checkout; pipeline writing decisions that involve any of these CLIs; debugging "command not found" or "command line argument" errors involving toolbox commands
+description: The Semaphore toolbox — CLIs preinstalled in every job for caching, artifacts, language version switching, services, retries, and SSH debugging. Authoritative reference for the cache / artifact / retry / sem-version / sem-service / checkout commands. Use when an agent needs to reason about Semaphore toolbox commands, questions arise about cache CLI semantics, artifact push/pull, sem-version, sem-service, retry, or checkout, pipeline-writing decisions involve any of these CLIs, or debugging "command not found" / "command line argument" errors involving toolbox commands.
 ---
 
 # Semaphore toolbox

--- a/assets/plugin/skills/testbox/SKILL.md
+++ b/assets/plugin/skills/testbox/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: testbox
-description: Run CI commands against local changes in a real Semaphore environment. Use when the user wants to test code before pushing, run tests in CI env, or iterate fast on fixes.
-when_to_use: >
-  Trigger on: "run tests", "test before pushing", "try this in CI", "does this pass",
-  "test my changes", "run the build", "check if tests pass", "spin up CI environment"
+description: Run CI commands against local changes in a real Semaphore environment. Use when the user wants to test code before pushing, run tests in CI env, or iterate fast on fixes — e.g. "run tests", "test before pushing", "try this in CI", "does this pass", "test my changes", "run the build", "check if tests pass", "spin up CI environment".
 user-invocable: false
 ---
 


### PR DESCRIPTION
## Summary

Removes the non-spec \`trigger:\` (7 skills) and \`when_to_use:\` (2 skills) frontmatter fields and folds their content into \`description:\`, per [agentskills.io/specification](https://agentskills.io/specification).

The spec prescribes that \`description:\`
> "should describe both what the skill does and when to use it"
> "should include specific keywords that help agents identify relevant tasks"

So the activation-keyword content that was in \`trigger:\` / \`when_to_use:\` belongs in \`description:\`.

## Why

VS Code's diagnostic flagged \`trigger:\` as unsupported. Verified against the Agent Skills spec — neither \`trigger:\` nor \`when_to_use:\` is in the recognized field list (\`name\`, \`description\`, \`license\`, \`compatibility\`, \`metadata\`, \`allowed-tools\`). Both were sem-ai-local extensions. Other Agent Skills hosts (Cursor, OpenCode, Gemini CLI, etc.) likely don't honor them either.

## Touched

- \`gha-to-semaphore\`, \`probe-agent-environment\`, \`sem-ai-bootstrap\`, \`semaphore-blocks\`, \`semaphore-promotions\`, \`semaphore-test-results\`, \`semaphore-toolbox\` (had \`trigger:\`)
- \`semaphore-ci\`, \`testbox\` (had \`when_to_use:\`)
- Other 5 skills already used description-only — untouched

All descriptions stay under the 1024-char spec limit (max: 578 chars).

## Test plan

- [x] All 14 skill frontmatters audited; zero off-spec fields remain
- [x] Max description length 578 / 1024 chars
- [ ] CI green
- [ ] Released as v0.1.13 — activation behavior should be equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)