### PR TITLE
feat(version): `--hook` flag emits JSON systemMessage for visible upgrade banner

### DIFF
--- a/assets/plugin/hooks/hooks.json
+++ b/assets/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v sem-ai >/dev/null 2>&1 && sem-ai version --check --notify-only-if-newer || printf 'sem-ai binary not found on PATH. Install:\\n  curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh\\n' >&2",
+            "command": "command -v sem-ai >/dev/null 2>&1 && sem-ai version --hook || printf '{\"systemMessage\": \"sem-ai binary not found on PATH. Install: curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh\"}\\n'",
             "timeout": 4
           }
         ]

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 var (
 	versionCheckFlag             bool
 	versionNotifyOnlyIfNewerFlag bool
+	versionHookFlag              bool
 )
 
 // upgradeHint is the canonical install.sh re-run command surfaced both in
@@ -27,8 +29,12 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Example: `  sem-ai version
   sem-ai version --check
-  sem-ai version --check --notify-only-if-newer`,
+  sem-ai version --check --notify-only-if-newer
+  sem-ai version --hook`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if versionHookFlag {
+			return runHookSystemMessage(cmd.Context(), cmd.OutOrStdout())
+		}
 		if versionNotifyOnlyIfNewerFlag {
 			return runNotifyOnlyIfNewer(cmd.Context(), cmd.ErrOrStderr())
 		}
@@ -129,6 +135,54 @@ func runNotifyOnlyIfNewer(ctx context.Context, stderr io.Writer) error {
 	return nil
 }
 
+// runHookSystemMessage is the Claude Code SessionStart-hook mode. Silent on
+// stdout when up to date; on a newer release available emits a JSON document
+// `{"systemMessage": "<two-line upgrade notice>"}` so Claude Code surfaces it
+// as a visible banner. Exit 0 always — hooks must not block.
+//
+// Why this and not --notify-only-if-newer: Claude Code SessionStart hooks
+// treat stderr as "user-only" (printed to the terminal, not surfaced in the
+// UI). To get a visible banner, the hook must emit JSON on stdout with the
+// documented `systemMessage` field.
+func runHookSystemMessage(ctx context.Context, stdout io.Writer) error {
+	if versioncheck.EnvOptOut() {
+		return nil
+	}
+
+	state, _, _ := versioncheck.ReadCache()
+	now := time.Now().UTC()
+
+	if !versioncheck.Fresh(state, now) {
+		fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		rel, err := versioncheck.Latest(fetchCtx)
+		if err != nil {
+			return nil // silent on error; LastCheckedAt NOT bumped so we retry
+		}
+		state.LastCheckedAt = now
+		state.LatestVersion = rel.Version
+		state.LatestPublishedAt = rel.PublishedAt
+		state.CurrentVersionWhenChecked = Version
+		_ = versioncheck.WriteCache(state)
+	}
+
+	newer, _ := versioncheck.Compare(Version, state.LatestVersion)
+	if !newer {
+		return nil
+	}
+
+	msg := fmt.Sprintf("sem-ai %s is available (you have %s). Upgrade:\n  %s",
+		state.LatestVersion, Version, upgradeHint)
+
+	payload, err := json.Marshal(map[string]string{"systemMessage": msg})
+	if err != nil {
+		return nil // best-effort; never block the session
+	}
+	fmt.Fprintln(stdout, string(payload))
+	return nil
+}
+
 // stderrIsTTY is a package-level var so tests can override it.
 var stderrIsTTY = func() bool {
 	info, err := os.Stderr.Stat()
@@ -212,5 +266,6 @@ func shouldSkipPersistentCheck(cmd *cobra.Command) bool {
 func init() {
 	versionCmd.Flags().BoolVar(&versionCheckFlag, "check", false, "check GitHub for a newer release")
 	versionCmd.Flags().BoolVar(&versionNotifyOnlyIfNewerFlag, "notify-only-if-newer", false, "(implies --check) silent unless a newer release exists; prints two-line stderr notice when newer")
+	versionCmd.Flags().BoolVar(&versionHookFlag, "hook", false, "Claude Code SessionStart-hook mode: silent on stdout when up to date; emits JSON {\"systemMessage\": ...} on stdout when a newer release exists")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -538,3 +538,86 @@ func TestRunNotifyOnlyIfNewer_StaleCacheRefreshes(t *testing.T) {
 		t.Errorf("stale cache should have been refreshed to 0.4.1; got:\n%s", buf.String())
 	}
 }
+
+func TestRunHookSystemMessage_UpToDate_Silent(t *testing.T) {
+	_, _ = withGitHubMock(t, "0.4.1", 200)
+
+	oldV := Version
+	Version = "0.4.1"
+	t.Cleanup(func() { Version = oldV })
+
+	buf := new(bytes.Buffer)
+	if err := runHookSystemMessage(context.Background(), buf); err != nil {
+		t.Fatalf("runHookSystemMessage: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected zero output when up to date; got: %q", buf.String())
+	}
+}
+
+func TestRunHookSystemMessage_Newer_EmitsJSON(t *testing.T) {
+	_, calls := withGitHubMock(t, "0.4.1", 200)
+
+	oldV := Version
+	Version = "0.3.0"
+	t.Cleanup(func() { Version = oldV })
+
+	buf := new(bytes.Buffer)
+	if err := runHookSystemMessage(context.Background(), buf); err != nil {
+		t.Fatalf("runHookSystemMessage: %v", err)
+	}
+	if got := atomic.LoadInt64(calls); got != 1 {
+		t.Errorf("HTTP calls = %d, want 1 (cold cache)", got)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw: %q", err, buf.String())
+	}
+	msg, ok := got["systemMessage"]
+	if !ok {
+		t.Fatalf("output missing systemMessage key; got: %q", buf.String())
+	}
+	if !strings.Contains(msg, "0.4.1") || !strings.Contains(msg, "0.3.0") {
+		t.Errorf("systemMessage missing versions; got: %q", msg)
+	}
+	if !strings.Contains(msg, "install.sh") {
+		t.Errorf("systemMessage missing install.sh hint; got: %q", msg)
+	}
+}
+
+func TestRunHookSystemMessage_HTTPFailure_Silent(t *testing.T) {
+	_, _ = withGitHubMock(t, "", 503)
+
+	oldV := Version
+	Version = "0.3.0"
+	t.Cleanup(func() { Version = oldV })
+
+	buf := new(bytes.Buffer)
+	if err := runHookSystemMessage(context.Background(), buf); err != nil {
+		t.Fatalf("runHookSystemMessage: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected zero output on HTTP failure; got: %q", buf.String())
+	}
+}
+
+func TestRunHookSystemMessage_OptOut_Silent(t *testing.T) {
+	_, calls := withGitHubMock(t, "0.4.1", 200)
+	t.Setenv("SEM_AI_NO_UPDATE_CHECK", "1")
+
+	oldV := Version
+	Version = "0.3.0"
+	t.Cleanup(func() { Version = oldV })
+
+	buf := new(bytes.Buffer)
+	if err := runHookSystemMessage(context.Background(), buf); err != nil {
+		t.Fatalf("runHookSystemMessage: %v", err)
+	}
+	if got := atomic.LoadInt64(calls); got != 0 {
+		t.Errorf("HTTP calls = %d, want 0 (env opt-out)", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected zero output on opt-out; got: %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Claude Code SessionStart hooks treat stderr as "user-only" — it prints to the terminal but is **NOT** surfaced as a system message in the UI. The existing \`version --check --notify-only-if-newer\` hook was therefore invisible: users on stale binaries (v0.1.6 through v0.1.13) never saw an upgrade banner even though the notification fired correctly on every session start.

New \`version --hook\` mode emits output Claude Code DOES surface:

\`\`\`
{"systemMessage": "sem-ai 0.1.14 is available (you have 0.1.11). Upgrade:\\n  curl -fsSL .../install.sh | sh"}
\`\`\`

…on stdout when a newer release exists; silent otherwise. Exit 0 always — hooks must not block.

\`assets/plugin/hooks/hooks.json\` now calls the new flag, and the missing-binary fallback also emits the same JSON shape so that path also surfaces a banner.

Per [code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks), \`systemMessage\` is the documented channel for visible warning banners from hooks.

## Test plan

- [x] \`go test ./...\` green (4 new tests cover up-to-date silent, newer emits JSON, HTTP failure silent, env opt-out silent)
- [x] Manual smoke: \`sem-ai version --hook\` silent at latest version; emits JSON when behind
- [ ] CI green
- [ ] Released as v0.1.14
- [ ] Manual: after release, a stale install (still on v0.1.13) opens a Claude Code session → upgrade banner visible

## Diff

- \`cmd/version.go\` — new \`--hook\` flag + \`runHookSystemMessage\`
- \`cmd/version_test.go\` — 4 new tests
- \`assets/plugin/hooks/hooks.json\` — hook command + fallback path both emit JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)