### PR TITLE
feat: `/sem-ai:init` slash command + plugin discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ make install
 
 Requires Go 1.25+.
 
+### Plugin install (Claude Code / Codex)
+
+sem-ai ships its skill bundle as a Claude Code / Codex plugin. From inside your AI host, install with two slash commands:
+
+```
+/plugin marketplace add semaphoreio/sem-ai
+/plugin install sem-ai@semaphoreio
+```
+
+The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox) into your host. Updates ride the marketplace — `/plugin update sem-ai@semaphoreio` whenever a new sem-ai release lands.
+
+Skills follow the [Agent Skills](https://agentskills.io) standard and give agents context on when and how to use each sem-ai command without reading documentation.
+
+#### Slash-command entry points
+
+User-invocable skills can be triggered directly with a namespaced slash command — useful when the activation keyword in a skill's description doesn't match your intent verbatim:
+
+| Slash command | What it does |
+|---|---|
+| `/sem-ai:init` | Initialize Semaphore CI/CD for the current repo — detects state (GHA present → translate; greenfield → from scratch; `.semaphore/` already → refine), applies defaults from the linked skills, validates, wires secrets, opens a PR |
+| `/sem-ai:gha-to-semaphore` | Translate only — same procedure as `init`'s translate path, scoped to converting `.github/workflows/*` |
+
+Other skills are loaded automatically when their description keywords match the user's prompt; the slash commands above are explicit triggers for the most common entry points.
+
 ## Updates
 
 When running the sem-ai plugin in Claude Code or Codex, a `SessionStart` hook checks GitHub for new releases at most once every 6 hours and surfaces a one-line notice in chat when one is available:
@@ -100,19 +124,6 @@ Add to `.mcp.json` in your project:
 ```
 
 All commands become native MCP tools (`project_list`, `diagnose`, `status`, `blast-radius`, etc). Long-running commands (`watch`, `promote-and-wait`) are excluded to prevent blocking.
-
-## Agent skills
-
-sem-ai ships its skill bundle as a Claude Code / Codex plugin. From inside your AI host, install with two slash commands:
-
-```
-/plugin marketplace add semaphoreio/sem-ai
-/plugin install sem-ai@semaphoreio
-```
-
-The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox) into your host. Updates ride the marketplace — `/plugin update sem-ai@semaphoreio` whenever a new sem-ai release lands.
-
-Skills follow the [Agent Skills](https://agentskills.io) standard and give agents context on when and how to use each sem-ai command without reading documentation.
 
 ## Commands
 

--- a/assets/plugin/skills/gha-to-semaphore/SKILL.md
+++ b/assets/plugin/skills/gha-to-semaphore/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gha-to-semaphore
-description: Translate a repo's GitHub Actions workflows into an equivalent Semaphore pipeline. ONLY covers the GHA→Semaphore mapping and conversion procedure; for Semaphore-side depth (cache CLI, test-results, blocks structure, sharding, promotions) defer to the linked skills. Use when the user asks to convert/port/migrate GitHub Actions to Semaphore, says "translate this workflow" or "convert ci.yml", or the repo has `.github/workflows/` and the user wants Semaphore instead.
+description: Translate a repo's GitHub Actions workflows into an equivalent Semaphore pipeline. ONLY covers the GHA→Semaphore mapping and conversion procedure; for Semaphore-side depth (cache CLI, test-results, blocks structure, sharding, promotions) defer to the linked skills. Use when the user asks to convert/port/migrate GitHub Actions to Semaphore, says "translate this workflow" or "convert ci.yml", or the repo has `.github/workflows/` and the user wants Semaphore instead. Can be invoked directly as `/sem-ai:gha-to-semaphore` (or via the broader `/sem-ai:init` orchestrator).
+user-invocable: true
 ---
 
 # Convert GitHub Actions to a Semaphore pipeline

--- a/assets/plugin/skills/init/SKILL.md
+++ b/assets/plugin/skills/init/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: init
+description: Initialize Semaphore CI/CD for the current repository — bootstrap the Semaphore project, write a working `.semaphore/semaphore.yml` (translating from GitHub Actions if present, or from scratch), wire required secrets, validate, and watch the first workflow. Applies Semaphore-side defaults automatically — agent image, toolbox CLIs, `test-results` epilogue rule, sharding heuristics — by routing through the linked skills. Use when the user wants to set up CI on Semaphore, says "initialize", "bootstrap CI", "prepare CI/CD for this project", "create a workflow on Semaphore", "make a `.semaphore` config", or runs `/sem-ai:init`.
+user-invocable: true
+---
+
+# `/sem-ai:init` — initialize Semaphore CI/CD for this repo
+
+The deterministic entry point for "make CI/CD work on Semaphore for this repository". Routes to the right path based on repo state and applies the defaults documented in the linked skills — so the agent doesn't fall back to training-data defaults that miss the per-skill guidance.
+
+This skill is an **orchestrator**. It does not duplicate depth from other skills; it loads them on demand. If you're skimming this and the answer to a question feels missing, the relevant detail is in one of the cross-linked skills below.
+
+## When to use this vs the underlying skills directly
+
+| Situation | Use |
+|---|---|
+| "Set up CI on Semaphore for this repo" (any state) | **`/sem-ai:init`** — this skill |
+| "Translate my GitHub Actions to Semaphore" (explicit) | `gha-to-semaphore` (or `/sem-ai:gha-to-semaphore`) |
+| "Explain how blocks / dependencies / parallelism work" | `semaphore-blocks` |
+| "What's the right way to use `cache` / `artifact` / `sem-version`" | `semaphore-toolbox` |
+| "Why don't my test reports show up" | `semaphore-test-results` |
+| "Is X preinstalled on the agent" | `probe-agent-environment` |
+
+`/sem-ai:init` is the user-facing slash command; the others are the depth it routes through.
+
+## Procedure
+
+### Step 1 — Detect repo state
+
+```bash
+ls .github/workflows/ 2>/dev/null
+ls .semaphore/ 2>/dev/null
+```
+
+Branch by what exists:
+
+| State | Path |
+|---|---|
+| `.github/workflows/*` present, no `.semaphore/` | **Translate path** — follow `gha-to-semaphore` end-to-end |
+| Neither | **Greenfield path** — see step 2 |
+| `.semaphore/*` already present | **Refine path** — ask the user before overwriting; default is to surface what's there and refine in-place rather than rewrite |
+
+### Step 2 — Greenfield: short interview before drafting
+
+If the repo has no existing CI, ask the user the minimal set of questions needed to draft something concrete:
+
+1. **What languages / runtimes?** (Inspect `package.json`, `go.mod`, `Gemfile`, `pyproject.toml`, etc., propose; ask only if unclear.)
+2. **What test commands?** (Read `package.json` scripts, `Makefile`, `mix.exs`, etc.)
+3. **Any managed services needed?** (Postgres, Redis, MySQL — match to `sem-service` supported list; see `semaphore-toolbox`.)
+4. **Any secrets used at build / test time?** (Don't ask for values — just names.)
+5. **Deploy step required?** (Default: no — pipeline runs tests only; add promotion later if needed. See `semaphore-promotions`.)
+
+Don't ask everything blindly — propose detected defaults and let the user correct.
+
+### Step 3 — Apply Semaphore-side defaults
+
+These come from the linked skills. Apply automatically; mention briefly in the PR body so the user knows what was chosen and why:
+
+- **Agent**: `type: f1-standard-2`, `os_image: ubuntu2404` (from `semaphore-blocks` runner table; per the official migration guide)
+- **`checkout`** in `global_job_config.prologue.commands:` (from `semaphore-toolbox`)
+- **`sem-version <lang> <ver>`** for language switching, NOT `apt-get install` / `nvm use` (from `semaphore-toolbox`)
+- **`cache` keyed on `$(checksum <lockfile>)` with fallback** for dependency caching (from `semaphore-toolbox` — cardinality: ONE path per `cache store`)
+- **`sem-service start <name>`** for postgres/mysql/redis/etc., NOT `services:` blocks (from `semaphore-toolbox`)
+- **`test-results publish` in `epilogue.always.commands:`** for JUnit reports — never inline (from `semaphore-test-results` — inline = silent on failure)
+- **Explicit `dependencies:` on every block** (from `semaphore-blocks` — all-or-none rule)
+- **Sharding via `parallelism: N` + the runner's native shard flag** when a test job has > N candidates (Cypress > 20 specs, Jest > 50 files, RSpec > 50, pytest > 100) — flag in PR body if applicable (from `semaphore-blocks` sharding table)
+
+If unsure whether a tool is preinstalled (uncommon flag, language version, custom CLI), spawn a short-lived testbox via `probe-agent-environment` — never write `apt-get install` / `curl | bash` for something Semaphore likely already ships.
+
+### Step 4 — Bootstrap the Semaphore project (if needed)
+
+```bash
+sem-ai project create --skip-yaml
+```
+
+`--skip-yaml` because we'll write the yaml ourselves in step 5. If the project already exists, `sem-ai project create` returns `{status: "exists", ...}` and exits 0 — safe to run.
+
+### Step 5 — Write the pipeline file
+
+Default file: `.semaphore/semaphore.yml`. For multi-pipeline cases (e.g. release on a separate promotion), additional files go under `.semaphore/<name>.yml`.
+
+Apply the defaults from step 3. For translate path, follow the `gha-to-semaphore` mapping table; for greenfield, write directly using the language's standard test invocation plus the defaults.
+
+### Step 6 — Validate
+
+```bash
+sem-ai yaml validate --file .semaphore/semaphore.yml
+```
+
+Iterate until clean. (Note: `sem-ai yaml validate` is currently authoritative for syntax; do not push if it fails for reasons other than transient infra errors.)
+
+### Step 7 — Wire secrets
+
+If step 2 (or the translate path) surfaced secret names, for each:
+
+```bash
+sem-ai secret create <NAME> --env <NAME>=<value>
+```
+
+**Never invent values.** Always ask the user. List every required secret in the PR body so the user can audit before merge.
+
+### Step 8 — Open a branch + PR
+
+- Branch name: `ci/semaphore` (or whatever fits the repo's convention)
+- PR body must include:
+  - **What was created** — block summary, defaults chosen
+  - **What was translated / from scratch** — clearly mark which
+  - **Secrets required** — names only
+  - **Differences vs prior CI** (if translate path) — fail-fast dropped, runner image picked, etc.
+  - **Speed suggestions** — sharding candidates flagged but not auto-applied
+- Do NOT push to upstream of an OSS repo. Work on the user's fork.
+- Do NOT merge the PR yourself. Leave it for the user.
+
+### Step 9 — Watch the first workflow
+
+```bash
+sem-ai workflow list --project <name> --limit 1
+```
+
+On failure: `sem-ai job log <job-id>`. Iterate fixes; surface any patterns worth feeding back as skill improvements.
+
+## Discipline
+
+- **One skill per concern** — don't restate `cache` semantics or `test-results` rules here; route through the depth-skills. Keeping this skill thin = easier to maintain.
+- **Ask before overwriting** — never blow away an existing `.semaphore/` without explicit user confirmation.
+- **Never invent secret values** — universal rule. Ask.
+- **Don't merge user PRs** — produce the artifact; the user reviews and merges.
+- **Surface what defaults were applied** — agents inheriting context from this skill should know that "the pipeline uses `f1-standard-2`" wasn't arbitrary — it's the documented default. Same for `test-results` in epilogue, etc.
+
+## Related skills
+
+- `gha-to-semaphore` — translation procedure + bucket classification + PR body template
+- `semaphore-blocks` — block/task/job model, dependencies, parallelism, sharding shard-flag table, agent selection
+- `semaphore-toolbox` — `cache`, `artifact`, `sem-version`, `sem-service`, `retry`, `checkout` CLIs + footguns
+- `semaphore-test-results` — JUnit publish + epilogue rule + per-framework configs + pipeline-level aggregation
+- `semaphore-promotions` — deploy gates, parameters, promotion chains (when the user asks for a deploy step)
+- `probe-agent-environment` — verify what's preinstalled before adding install steps
+- `manage-infra` — secret create, deploy targets, agent types

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,10 @@ if [ -x "$dest" ]; then
   installed_ver_stripped=${installed_ver#v}
   if [ -n "$installed_ver_stripped" ] && [ "$installed_ver_stripped" = "$ver" ]; then
     say "sem-ai ${tag} is already the latest version"
+    say ""
+    say "If you use Claude Code or Codex, refresh the plugin to pick up the latest skills:"
+    say "  /plugin update sem-ai@semaphoreio"
+    say "(First time? Install with:  /plugin marketplace add semaphoreio/sem-ai && /plugin install sem-ai@semaphoreio )"
     exit 0
   fi
 fi
@@ -107,3 +111,10 @@ if [ "$path_hint" = "1" ]; then
   warn "note: add ${dest_dir} to your PATH (e.g. add 'export PATH=\"\$HOME/.semaphore-ai/bin:\$PATH\"' to ~/.profile)"
 fi
 say "installed sem-ai ${tag} to ${dest}"
+say ""
+say "If you use Claude Code or Codex, install (or refresh) the skill bundle:"
+say "  /plugin marketplace add semaphoreio/sem-ai"
+say "  /plugin install sem-ai@semaphoreio        # first time"
+say "  /plugin update  sem-ai@semaphoreio        # already installed"
+say ""
+say "Then run /sem-ai:init in a repo to set up Semaphore CI/CD for it."


### PR DESCRIPTION
## Summary

Closes the activation gap surfaced by a real-world dogfood session: user asked "prepare me a fully working CI/CD pipeline for this project in semaphore", zero skills fired, agent fell back to training defaults that violated multiple skill recommendations.

Adds a deterministic entry point so the user (and agents acting on user intent) can trigger the full set-up flow without relying on description-keyword matching.

## Changes

### New: \`/sem-ai:init\` orchestrator skill

\`assets/plugin/skills/init/SKILL.md\` (user-invocable). Detects repo state and routes:

| State | Path |
|---|---|
| \`.github/workflows/*\` present, no \`.semaphore/\` | Translate via \`gha-to-semaphore\` |
| Neither | Greenfield — short interview then draft |
| \`.semaphore/*\` already present | Ask before overwriting; refine in place by default |

Applies Semaphore-side defaults from the linked skills:
- \`f1-standard-2\` + \`ubuntu2404\` agent (per migration guide)
- \`checkout\` in \`global_job_config.prologue\` (from \`semaphore-toolbox\`)
- \`sem-version <lang> <ver>\` (not apt-get / nvm)
- \`cache\` keyed on \`\$(checksum <lockfile>)\` with fallback — one path per \`cache store\`
- \`sem-service start\` for managed services (postgres, redis, ...)
- \`test-results publish\` in \`epilogue.always.commands:\` — never inline (silent on failure)
- Explicit \`dependencies:\` on every block (all-or-none rule)
- Sharding via \`parallelism: N\` + the runner's native shard flag when applicable

Stays thin — does NOT duplicate depth from \`semaphore-toolbox\` / \`semaphore-blocks\` / \`semaphore-test-results\`; cross-links instead.

### \`gha-to-semaphore\`: \`user-invocable: true\`

So \`/sem-ai:gha-to-semaphore\` works as the direct translate-only entry point.

### README

- **Plugin install section moved** up next to the binary install section (was buried below MCP + Quick start). User-facing install flow now reads top-to-bottom: install binary → install plugin → quick start.
- New **"Slash-command entry points"** table documenting \`/sem-ai:init\` and \`/sem-ai:gha-to-semaphore\`.

### \`install.sh\`

On successful install AND on already-latest fast-path, prints a next-step hint telling the user to install/update the plugin and then run \`/sem-ai:init\`. Closes the loop between "I installed sem-ai" and "now what" for first-time users.

## Test plan

- [x] \`/sem-ai:init\` skill written; cross-links to all relevant depth skills
- [x] \`gha-to-semaphore\` marked user-invocable
- [x] README install flow reads coherently top-to-bottom
- [x] install.sh emits plugin hint in both install paths (fresh + fast-path)
- [ ] CI green
- [ ] Bundled release as v0.1.15 (held until any follow-up changes also land per project-tasks#3401)
- [ ] Manual: re-run the alpine demo with \`/sem-ai:init\` as the trigger; verify defaults land (toolbox CLIs, epilogue test-results, sharding suggestion, agent image)

## Tracker

renderedtext/project-tasks#3401

🤖 Generated with [Claude Code](https://claude.com/claude-code)