### PR TITLE
fix(skills): pull test-results instead of patching pipeline

### DIFF
--- a/assets/plugin/skills/semaphore-test-results/SKILL.md
+++ b/assets/plugin/skills/semaphore-test-results/SKILL.md
@@ -190,6 +190,52 @@ When sharding Cypress across N jobs (see `semaphore-blocks` parallelism), each s
 
 If you skip `gen-pipeline-report`, the per-job tabs still work, but the rolled-up pipeline view is empty.
 
+## Debugging a failed job — pull, don't tweak
+
+If your pipeline already publishes JUnit and a test fails, **don't change the reporter to also dump to stdout, and don't re-run with `-v`**. The failure detail is already published — pull it.
+
+```bash
+sem-ai test summary --pipeline <pipeline-id>
+# → verdict, total/passed/failed/skipped, per-failure: test name, file:line, message
+
+sem-ai test report --pipeline <pipeline-id>
+# → per-job view; tries the junit artifact first, falls back to log parsing
+
+sem-ai artifact get --scope jobs --id <job-id> --path junit-<name>.xml --output local.xml
+# → raw artifact when you want to inspect it yourself
+```
+
+See `test-intelligence` skill for full surface.
+
+### When to use which
+
+- **`test summary`** — first move when a pipeline went red. Compact digest. Right answer 90% of the time.
+- **`test report`** — when summary doesn't have enough; per-job breakdown.
+- **`artifact get`** — when you want the raw junit XML (e.g. to diff against a previous run, feed into other tooling).
+
+### Anti-pattern — junit-only reporter
+
+A test runner configured with **only** a JUnit reporter (Vitest `--reporter=junit` and nothing else; mocha-junit-reporter with `toConsole: false`; Jest with junit-only setup) produces zero human-readable output in the job log. When something fails, the log shows "exit 1" and nothing about which test broke.
+
+**Don't configure runners this way to begin with.** Keep the framework's default reporter alongside the JUnit one — the default reporter is calibrated to be useful without flooding the log (test names, failure messages, summary; no per-assertion noise). You get readable logs *and* the structured Test Reports tab.
+
+Concrete shapes:
+
+| Framework | Don't | Do |
+|---|---|---|
+| Vitest | `--reporter=junit` | `--reporter=default --reporter=junit` |
+| mocha / cypress-junit | `toConsole: false` | `toConsole: true` (or `mocha-multi-reporters` with `spec` + `mocha-junit-reporter`) |
+| Jest | only `jest-junit` in `reporters:` | `["default", ["jest-junit", { ... }]]` |
+| pytest | `--quiet --junitxml=...` | `--junitxml=...` (drop `--quiet`) |
+| RSpec | only `--format RspecJunitFormatter` | `--format progress --format RspecJunitFormatter --out junit-rspec.xml` |
+| gotestsum | `--format=junit` only | default `--format=pkgname` writes log; `--junitfile` adds junit |
+
+**Rule**: more log = better debugging, up to the point of flooding. Defaults across frameworks are well-tuned for this — keep them on, add JUnit alongside. Avoid `-v` / `--verbose` flags unless you actually need per-assertion trace; those triple log size for marginal debugging value.
+
+### If you DID end up junit-only, still don't change the pipeline first
+
+`sem-ai test summary --pipeline <id>` parses the junit artifact and prints a digest in under a second. Use that to identify what failed *before* deciding whether the right fix is a reporter config change or a code change. Patching the pipeline to dump more output, re-running, and waiting another few minutes is rarely the right first move — pull what's already published.
+
 ## Common failure modes
 
 ### "I see no test report, but the job's command produced junit-foo.xml"

--- a/assets/plugin/skills/semaphore-toolbox/SKILL.md
+++ b/assets/plugin/skills/semaphore-toolbox/SKILL.md
@@ -80,16 +80,24 @@ Cache is keyed; artifact is path-named. Cache LRU-evicts; artifact has explicit 
 
 ### FOOTGUN — cache-hit skips package postinstall hooks
 
-If `node_modules` is restored from cache, `npm install` says "up to date" and **skips postinstall hooks**. That means:
-- Cypress's postinstall (which downloads the actual Cypress binary into `~/.cache/Cypress`) doesn't fire → tests fail with "binary not found".
-- Playwright's postinstall (browser binaries) — same.
-- Anything with a postinstall download — same.
+If `node_modules` is restored from cache, `npm install` says "up to date" and **skips postinstall hooks**. The hooks are where downloaders like browser-test runners fetch their actual binary (separate from the npm package), so the cache hit silently breaks the binary.
 
-Two fixes:
-1. Also cache the binary dir: `cache restore cypress-bin-$(checksum package-lock.json)` and store `~/.cache/Cypress`.
-2. After `npm install`, run the postinstall trigger explicitly: `npx cypress install`, `npx playwright install`, etc.
+Examples in the wild:
+- Cypress postinstall downloads the runner binary into `~/.cache/Cypress` → next run fails with "binary not found".
+- Playwright postinstall downloads browser binaries into `~/.cache/ms-playwright` → same.
+- Any package with a fetch-binary postinstall — same shape.
 
-Option 1 is cheaper at runtime but pollutes cache keys; option 2 is simpler and adds <10s.
+**Rule (preferred)**: redirect the tool's binary directory into a path that's already part of your dependency-cache scope. Each tool reads an env var for its binary location:
+
+| Tool | Env var | Set it to |
+|---|---|---|
+| Cypress | `CYPRESS_CACHE_FOLDER` | a subdir of `$HOME/.npm` or your project's `node_modules/.cache/cypress` |
+| Playwright | `PLAYWRIGHT_BROWSERS_PATH` | similar — inside the deps cache |
+| Puppeteer | `PUPPETEER_CACHE_DIR` | similar |
+
+Set the env var in `global_job_config.env_vars:` (so every job sees it consistently) and the binary is then naturally bundled into your existing dependency-cache restore. No extra cache key, no manual postinstall trigger.
+
+**Fallback** when an env-var redirect isn't available: explicit postinstall trigger after `npm install`, e.g. `npx cypress install` / `npx playwright install`. Adds ~10s per run but works for any tool. Or cache the binary dir separately (its own `cache restore` / `cache store` keyed on the lockfile), which is cheap at runtime but multiplies cache keys.
 
 ---
 

--- a/assets/plugin/skills/test-intelligence/SKILL.md
+++ b/assets/plugin/skills/test-intelligence/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-intelligence
-description: Analyze test results, detect flaky tests, parse JUnit artifacts. Supports Go, pytest, rspec, minitest, jest, ExUnit.
+description: Pull and analyze test results from a Semaphore pipeline — failure detail, flaky-test detection, JUnit parsing. Use when a job failed and you need to see WHICH test broke without changing the pipeline config or re-running; when a junit-only reporter hides failure detail in the log; when you're about to add a stdout reporter just to debug — pull the published JUnit artifact instead via `sem-ai test summary` / `sem-ai test report` / `sem-ai artifact get`. Supports Go, pytest, rspec, minitest, jest, ExUnit.
 user-invocable: false
 ---
 


### PR DESCRIPTION
## Summary

Three skill updates driven by the second alpine demo (\`/sem-ai:init\`):

### 1. \`test-intelligence\` description broadened

Previously only mentioned "analyze test results" / "flaky tests" — didn't match user phrasing like "Vitest exited 1, junit-only reporter hides what failed". Now leads with debug-failed-test intent so it activates when most needed.

### 2. \`semaphore-test-results\` — new "Debugging a failed job — pull, don't tweak" section

When a junit-only reporter hides failure detail in the log, the right move is:

\`\`\`bash
sem-ai test summary --pipeline <id>   # parses published junit, <1s
\`\`\`

…NOT editing the reporter config, redeploying, and re-running. Includes:

- \`test summary\` / \`test report\` / \`artifact get\` when-to-use table
- **Anti-pattern: junit-only reporter** with per-framework Don't/Do table covering Vitest, mocha-junit \`toConsole:true\`, Jest, pytest, RSpec, gotestsum
- **Rule**: more log = better debugging, up to the point of flooding. Framework defaults are well-tuned — keep them on, add JUnit alongside. Don't \`-v\` / \`--verbose\` flag-bomb.

### 3. \`semaphore-toolbox\` — postinstall footgun rewritten

Promotes env-var redirect as the primary fix for "cache-hit silently skips Cypress/Playwright/Puppeteer postinstall binary download":

| Tool | Env var |
|---|---|
| Cypress | \`CYPRESS_CACHE_FOLDER\` |
| Playwright | \`PLAYWRIGHT_BROWSERS_PATH\` |
| Puppeteer | \`PUPPETEER_CACHE_DIR\` |

Set in \`global_job_config.env_vars:\` to a subdir of an already-cached path → binary lands inside dep-cache naturally. No extra cache keys, no manual postinstall trigger. Old advice (explicit \`npx cypress install\` / separate binary cache key) demoted to fallback.

## Why

Specific friction from alpine demo session this morning:
- Agent saw "Vitest exited 1" with junit-only reporter → patched pipeline to add stdout reporter + re-ran (~3min lost) instead of \`sem-ai test summary\` (~1s)
- Agent rediscovered Cypress binary-not-cached footgun and applied the workaround (\`npx cypress install\`) instead of the cleaner env-var redirect

## Test plan

- [x] Markdown-only changes
- [ ] CI green
- [ ] Released (bundle TBD per project-tasks#3401 follow-ups)
- [ ] Re-run alpine demo a third time — confirm agent fires \`sem-ai test summary\` on test failure instead of editing reporter config

## Tracker

renderedtext/project-tasks#3401 (will mark "Re-run the alpine demo" complete once verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)