### PR TITLE
fix: stop advertising non-existent `/plugin update <plugin>` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,16 @@ sem-ai ships its skill bundle as a Claude Code / Codex plugin. From inside your 
 /plugin install sem-ai@semaphoreio
 ```
 
-The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox) into your host. Updates ride the marketplace — `/plugin update sem-ai@semaphoreio` whenever a new sem-ai release lands.
+The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox) into your host.
+
+Updates ride the marketplace's `autoUpdate: true` flag — Claude Code refreshes the catalog at session start and picks up new skill versions automatically. To force an immediate refresh:
+
+```
+/plugin marketplace update semaphoreio
+/reload-plugins
+```
+
+(Note: there is no `/plugin update <plugin>@<marketplace>` command — refresh the marketplace and let auto-update apply, or `uninstall` + `install` for a forced re-install.)
 
 Skills follow the [Agent Skills](https://agentskills.io) standard and give agents context on when and how to use each sem-ai command without reading documentation.
 

--- a/install.sh
+++ b/install.sh
@@ -72,8 +72,9 @@ if [ -x "$dest" ]; then
   if [ -n "$installed_ver_stripped" ] && [ "$installed_ver_stripped" = "$ver" ]; then
     say "sem-ai ${tag} is already the latest version"
     say ""
-    say "If you use Claude Code or Codex, refresh the plugin to pick up the latest skills:"
-    say "  /plugin update sem-ai@semaphoreio"
+    say "If you use Claude Code or Codex, refresh the marketplace so the new skills land next session:"
+    say "  /plugin marketplace update semaphoreio"
+    say "  /reload-plugins         # apply now, no restart"
     say "(First time? Install with:  /plugin marketplace add semaphoreio/sem-ai && /plugin install sem-ai@semaphoreio )"
     exit 0
   fi
@@ -113,8 +114,9 @@ fi
 say "installed sem-ai ${tag} to ${dest}"
 say ""
 say "If you use Claude Code or Codex, install (or refresh) the skill bundle:"
-say "  /plugin marketplace add semaphoreio/sem-ai"
-say "  /plugin install sem-ai@semaphoreio        # first time"
-say "  /plugin update  sem-ai@semaphoreio        # already installed"
+say "  /plugin marketplace add semaphoreio/sem-ai     # first time only"
+say "  /plugin install sem-ai@semaphoreio             # first time"
+say "  /plugin marketplace update semaphoreio         # already installed — refresh catalog"
+say "  /reload-plugins                                # apply changes without restart"
 say ""
 say "Then run /sem-ai:init in a repo to set up Semaphore CI/CD for it."


### PR DESCRIPTION
## Summary

Claude Code has no \`/plugin update sem-ai@semaphoreio\` command — users who followed our install.sh hint or README guidance silently got no update and assumed the plugin system was broken (user feedback today after v0.1.16 release didn't surface despite the autoUpdate marketplace setting).

Per [docs.claude.com/en/discover-plugins](https://code.claude.com/docs/en/discover-plugins) the real shape is:

- Marketplaces support \`autoUpdate: true\` (we already set this) — plugin updates at session start automatically
- \`/plugin marketplace update <marketplace>\` — refreshes the catalog
- \`/reload-plugins\` — applies changes without restart
- For forced re-install: \`uninstall\` + \`install\` (no in-place \`update\` verb for plugins)

## Changes

- \`install.sh\` — both the already-latest fast-path AND the post-install hint now print the correct sequence (\`/plugin marketplace update semaphoreio\` + \`/reload-plugins\`).
- \`README.md\` — the one-liner "/plugin update sem-ai@semaphoreio when a new release lands" replaced with an explanation of the \`autoUpdate\` semantics + the actual refresh commands + an explicit note that the bogus command doesn't exist (saves the next round of confusion).

## Test plan

- [x] Docs-only / shell-only — no code path changed
- [ ] CI green
- [ ] After merge: re-run \`install.sh\` on a fresh shell, verify the printed commands match what Claude Code accepts
- [ ] No release tag — fix to instructional text; will pick up in v0.1.17 whenever next code change ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)