### PR TITLE
docs(skills): poll on `result`, not `state` + cache-key bust on env-var transition

### DIFF
--- a/assets/plugin/skills/semaphore-blocks/SKILL.md
+++ b/assets/plugin/skills/semaphore-blocks/SKILL.md
@@ -261,6 +261,27 @@ To pre-flight YAML syntax before pushing:
 sem-ai yaml validate --file .semaphore/semaphore.yml
 ```
 
+### Polling a pipeline to terminal state — `result`, not `state`
+
+When waiting for a pipeline to finish (e.g. background `until` loops watching first-run completion), check the **`result`** field, not `state`:
+
+- `state` — `RUNNING`, `STOPPING`, `DONE` — has intermediate values that show up on nested objects (e.g. each block has its own `state: DONE` once the block finishes, while the parent pipeline is still running).
+- `result` — `PASSED`, `FAILED`, `STOPPED`, `CANCELED` — only populated when the **pipeline itself** terminates.
+
+Polling `state == "DONE"` will fire false positives on inner block transitions. Polling `result != ""` (or `result in ("PASSED","FAILED","STOPPED","CANCELED")`) only fires when the pipeline is genuinely terminal.
+
+```bash
+# Correct
+until result=$(sem-ai pipeline show "$id" --jq '.pipeline.result // ""') && [ -n "$result" ]; do
+  sleep 30
+done
+
+# WRONG — fires on intermediate block-state="done" before pipeline ends
+until sem-ai pipeline show "$id" --jq '.pipeline.state' | grep -q done; do
+  sleep 30
+done
+```
+
 ## Common patterns
 
 ### Fan-out, fan-in (Quality → Build)

--- a/assets/plugin/skills/semaphore-toolbox/SKILL.md
+++ b/assets/plugin/skills/semaphore-toolbox/SKILL.md
@@ -97,6 +97,8 @@ Examples in the wild:
 
 Set the env var in `global_job_config.env_vars:` (so every job sees it consistently) and the binary is then naturally bundled into your existing dependency-cache restore. No extra cache key, no manual postinstall trigger.
 
+**First-run gotcha when introducing the env var**: the very first pipeline after you add the env-var redirect will restore the existing cache key (which was populated WITHOUT the binary subpath), `npm ci` will say "up to date", and the binary will still be missing. The fix is either to bust the cache key once (add a version suffix like `node-modules-v2-$(checksum package-lock.json)` so the next run starts fresh and bundles the binary) OR keep an explicit `npx cypress install` step as belt-and-braces for the transition. Both are one-time costs; after the cache rotates once, the env-var redirect alone is enough.
+
 **Fallback** when an env-var redirect isn't available: explicit postinstall trigger after `npm install`, e.g. `npx cypress install` / `npx playwright install`. Adds ~10s per run but works for any tool. Or cache the binary dir separately (its own `cache restore` / `cache store` keyed on the lockfile), which is cheap at runtime but multiplies cache keys.
 
 ---


### PR DESCRIPTION
Two patches from the latest /sem-ai:init alpine session.

**semaphore-blocks** — when polling pipeline completion, check `result` (PASSED/FAILED/STOPPED/CANCELED), NOT `state`. `state` has intermediate `DONE` values on inner blocks while the pipeline still runs. Agent's poll loop in the demo grepped "done" and fired false-positive mid-run.

**semaphore-toolbox** — postinstall env-var redirect (CYPRESS_CACHE_FOLDER etc) has a first-run gotcha: existing cache key restores node_modules built BEFORE the env-var was set, so the binary subpath is empty. Bust the cache key once OR keep explicit `npx cypress install` as belt-and-braces during transition.

Tracker: renderedtext/project-tasks#3401