### PR TITLE
fix(marketplace): drop no-op autoUpdate flag, add marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,10 +1,10 @@
 {
   "name": "semaphoreio",
+  "description": "Agent-first Semaphore CI/CD tooling for Claude Code — skills and MCP integration to manage pipelines, tests, deploys, and infrastructure.",
   "owner": {
     "name": "Semaphore CI",
     "url": "https://semaphoreci.com"
   },
-  "autoUpdate": true,
   "plugins": [
     {
       "name": "sem-ai",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sem-ai ships its skill bundle as a Claude Code / Codex plugin. From inside your 
 
 The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox) into your host.
 
-Updates ride the marketplace's `autoUpdate: true` flag — Claude Code refreshes the catalog at session start and picks up new skill versions automatically. To force an immediate refresh:
+Claude Code refreshes registered marketplaces at session start, picks up the new plugin version, and applies it automatically — there is no manifest flag to set for this. To force an immediate refresh:
 
 ```
 /plugin marketplace update semaphoreio


### PR DESCRIPTION
## What

- Remove `autoUpdate: true` from `.claude-plugin/marketplace.json` — it is not part of the marketplace manifest schema. Claude Code ignores it at load, and the manifest validator flags it as an unknown field, failing under `--strict`.
- Add a top-level `description` to the marketplace so it passes strict validation and reads well in the plugin directory.
- Fix the README plugin-update section, which claimed updates "ride the marketplace's `autoUpdate: true` flag." That flag never did anything.

## Why

Plugin auto-update is handled by Claude Code itself: it refreshes registered marketplaces at session start and applies new plugin versions. There is no manifest-level flag to opt into this. Keeping a no-op field in the manifest both fails strict validation and misleads readers via the README.

## Validation

`marketplace.json` now passes the manifest validator with no warnings (no unknown field, description present).