### PR TITLE
fix(plugin): make Codex marketplace entry installable (#36)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,10 +9,16 @@
     {
       "name": "sem-ai",
       "source": {
-        "path": "../../assets/plugin"
+        "source": "local",
+        "path": "./assets/plugin"
       },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.5"
+      "version": "0.1.18"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -38,11 +38,20 @@ Requires Go 1.25+.
 
 ### Plugin install (Claude Code / Codex)
 
-sem-ai ships its skill bundle as a Claude Code / Codex plugin. From inside your AI host, install with two slash commands:
+sem-ai ships its skill bundle as a Claude Code / Codex plugin.
+
+**Claude Code** — from inside the host, install with two slash commands:
 
 ```
 /plugin marketplace add semaphoreio/sem-ai
 /plugin install sem-ai@semaphoreio
+```
+
+**Codex CLI** — install from the shell:
+
+```sh
+codex plugin marketplace add semaphoreio/sem-ai
+codex plugin add sem-ai@semaphoreio
 ```
 
 The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox) into your host.

--- a/assets/plugin/.codex-plugin/plugin.json
+++ b/assets/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "sem-ai",
+  "version": "0.1.18",
+  "description": "Agent-first Semaphore CI/CD client — skills bundle",
+  "homepage": "https://github.com/semaphoreio/sem-ai",
+  "repository": "https://github.com/semaphoreio/sem-ai",
+  "author": {
+    "name": "Semaphore CI",
+    "url": "https://semaphoreci.com"
+  },
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}


### PR DESCRIPTION
## Summary

Fixes #36 — Codex CLI couldn't install the `sem-ai` plugin from this marketplace.

Three problems in the Codex-side packaging:

- `.agents/plugins/marketplace.json` was missing Codex-required fields (`source.source`, `policy.installation`, `policy.authentication`, `category`).
- `source.path` used `../../assets/plugin`, which violates Codex's path rule (must start with `./`, stay inside marketplace root). Changed to `./assets/plugin` — both Claude Code and Codex resolve plugin `source.path` relative to the repo root, not the directory containing `marketplace.json`.
- Codex expects the plugin manifest at `<plugin>/.codex-plugin/plugin.json`; we only shipped `assets/plugin/plugin.json`. Added the Codex-format manifest with `skills` and `mcpServers` pointers so Codex actually loads the bundle.

Also bumped the marketplace entry's `version` from `0.1.5` → `0.1.18` to match `plugin.json` (the stale value would have masked the real version per Claude Code docs).

The Claude-Code-side marketplace (`.claude-plugin/marketplace.json`) is untouched.

## Test plan

- [x] `codex plugin marketplace add semaphoreio/sem-ai --ref fix/codex-plugin-install-issue-36` → success
- [x] `codex plugin list` shows `sem-ai@semaphoreio` as installable with correct path
- [x] `codex plugin add sem-ai@semaphoreio` → installed at `~/.codex/plugins/cache/semaphoreio/sem-ai/0.1.18/`
- [x] Installed plugin contains all 15 skills, `.codex-plugin/plugin.json`, `.mcp.json`
- [x] Verify Claude Code install still works (`/plugin marketplace add semaphoreio/sem-ai@fix/codex-plugin-install-issue-36`)