### PR TITLE
chore(release): bump plugin manifests to v0.1.19

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.18"
+      "version": "0.1.19"
     }
   ]
 }

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {


### PR DESCRIPTION
Bumps plugin manifests `0.1.18 → 0.1.19` (marketplace.json + plugin.json).

Ships PR #42 (drop v2 API callers → v1alpha; task create / pipeline topology / api-spec) to plugin users.