### PR TITLE
feat(diagnose): interpret signal exit codes (130 → SIGINT, etc.)

### DIFF
--- a/cmd/diagnose.go
+++ b/cmd/diagnose.go
@@ -9,6 +9,7 @@ import (
 	"github.com/semaphoreio/sem-ai/pkg/client"
 	"github.com/semaphoreio/sem-ai/pkg/config"
 	"github.com/semaphoreio/sem-ai/pkg/output"
+	"github.com/semaphoreio/sem-ai/pkg/signals"
 	"github.com/semaphoreio/sem-ai/pkg/testparse"
 	"github.com/spf13/cobra"
 )
@@ -145,15 +146,19 @@ If no workflow ID is given, finds the latest workflow for the current project/br
 
 		// Find failed blocks and jobs
 		type failedJob struct {
-			Block     string              `json:"block"`
-			JobName   string              `json:"job_name"`
-			JobID     string              `json:"job_id"`
-			LogTail   string              `json:"log_tail,omitempty"`
+			Block      string                `json:"block"`
+			JobName    string                `json:"job_name"`
+			JobID      string                `json:"job_id"`
+			LogTail    string                `json:"log_tail,omitempty"`
+			Signal     *signals.Info         `json:"signal,omitempty"`
 			TestReport *testparse.TestReport `json:"test_report,omitempty"`
 		}
 
 		failedJobs := make([]failedJob, 0)
 		failedBlocks := make([]string, 0)
+		// stopReason captures the first signal-induced stop across all jobs, so
+		// the diagnosis surfaces "why did this silently stop" at the top level.
+		var stopReason *signals.Info
 
 		for _, block := range pplData.Blocks {
 			if block.Result != "passed" && block.Result != "" {
@@ -187,7 +192,13 @@ If no workflow ID is given, finds the latest workflow for the current project/br
 									allOutput.WriteString(e.Output)
 								}
 								if e.ExitCode != 0 && e.Directive != "" {
-									failedCmds = append(failedCmds, fmt.Sprintf("$ %s (exit %d)", e.Directive, e.ExitCode))
+									sig := signals.Interpret(e.ExitCode)
+									if sig != nil {
+										failedCmds = append(failedCmds, fmt.Sprintf("$ %s (exit %d — %s)", e.Directive, e.ExitCode, sig.Signal))
+										fj.Signal = sig // last signal-bearing command wins (the trigger)
+									} else {
+										failedCmds = append(failedCmds, fmt.Sprintf("$ %s (exit %d)", e.Directive, e.ExitCode))
+									}
 								}
 							}
 
@@ -206,6 +217,9 @@ If no workflow ID is given, finds the latest workflow for the current project/br
 						}
 					}
 
+					if stopReason == nil && fj.Signal != nil {
+						stopReason = fj.Signal
+					}
 					failedJobs = append(failedJobs, fj)
 				}
 			}
@@ -237,6 +251,13 @@ If no workflow ID is given, finds the latest workflow for the current project/br
 			"failed_blocks":  failedBlocks,
 			"failed_jobs":    failedJobs,
 			"total_blocks":   len(pplData.Blocks),
+		}
+
+		// Additive: explain a signal-induced stop. Most actionable for exit 130,
+		// where the job shows STOPPED (not FAILED) and failure notifications are
+		// silently suppressed.
+		if stopReason != nil {
+			diagnosis["stop_reason"] = stopReason
 		}
 
 		output.Result(diagnosis)

--- a/cmd/job.go
+++ b/cmd/job.go
@@ -9,6 +9,7 @@ import (
 	"github.com/semaphoreio/sem-ai/pkg/client"
 	"github.com/semaphoreio/sem-ai/pkg/config"
 	"github.com/semaphoreio/sem-ai/pkg/output"
+	"github.com/semaphoreio/sem-ai/pkg/signals"
 	"github.com/spf13/cobra"
 )
 
@@ -96,7 +97,7 @@ var jobLogCmd = &cobra.Command{
 					sb.WriteString(e.Output)
 				case "cmd_finished":
 					if e.ExitCode != 0 {
-						sb.WriteString(fmt.Sprintf("\n[exit code: %d]\n", e.ExitCode))
+						sb.WriteString(fmt.Sprintf("\n[exit code: %d%s]\n", e.ExitCode, signals.Annotate(e.ExitCode)))
 					}
 				case "job_finished":
 					sb.WriteString(fmt.Sprintf("\n[job result: %s]\n", e.JobResult))
@@ -106,14 +107,16 @@ var jobLogCmd = &cobra.Command{
 			return nil
 		}
 
-		// JSON/YAML: structured events
+		// JSON/YAML: structured events. Signal is additive — exit_code is always
+		// preserved; signal/signal_no/meaning are extra context for 128+N codes.
 		type logEvent struct {
-			Timestamp int64  `json:"timestamp"`
-			Type      string `json:"type"`
-			Output    string `json:"output,omitempty"`
-			Command   string `json:"command,omitempty"`
-			ExitCode  int    `json:"exit_code,omitempty"`
-			JobResult string `json:"job_result,omitempty"`
+			Timestamp int64         `json:"timestamp"`
+			Type      string        `json:"type"`
+			Output    string        `json:"output,omitempty"`
+			Command   string        `json:"command,omitempty"`
+			ExitCode  int           `json:"exit_code,omitempty"`
+			Signal    *signals.Info `json:"signal,omitempty"`
+			JobResult string        `json:"job_result,omitempty"`
 		}
 
 		events := make([]logEvent, 0, len(logs.Events))
@@ -124,6 +127,7 @@ var jobLogCmd = &cobra.Command{
 				Output:    e.Output,
 				Command:   e.Directive,
 				ExitCode:  e.ExitCode,
+				Signal:    signals.Interpret(e.ExitCode),
 				JobResult: e.JobResult,
 			})
 		}

--- a/pkg/signals/signals.go
+++ b/pkg/signals/signals.go
@@ -1,0 +1,59 @@
+// Package signals interprets process exit codes, focusing on the 128+N
+// convention where a non-zero code means the process was terminated by signal N.
+//
+// On Semaphore this matters because a tool exiting 130 (SIGINT) leads the agent
+// to mark the job STOPPED rather than FAILED — which silently suppresses the
+// usual "build failed" notifications. Surfacing the signal turns an opaque
+// exit code into an actionable explanation.
+package signals
+
+import "fmt"
+
+// Info describes an exit code's signal interpretation. It is purely additive —
+// callers keep the raw exit code and attach this alongside it.
+type Info struct {
+	ExitCode int    `json:"exit_code"`
+	Signal   string `json:"signal,omitempty"`   // e.g. "SIGINT"
+	SignalNo int    `json:"signal_no,omitempty"` // e.g. 2
+	Meaning  string `json:"meaning,omitempty"`  // human/agent-readable cause
+}
+
+// known maps signal numbers to (name, meaning) for the signals a CI job is
+// realistically killed by. The exit code is 128+number.
+var known = map[int]struct{ name, meaning string }{
+	2:  {"SIGINT", "interrupted (Ctrl-C / SIGINT); Semaphore agent marks the job STOPPED, not FAILED, so failure notifications won't fire"},
+	9:  {"SIGKILL", "force-killed — usually out-of-memory (OOM) or hitting a hard resource limit"},
+	15: {"SIGTERM", "terminated (SIGTERM) — typically a timeout or an external stop request"},
+	11: {"SIGSEGV", "segmentation fault — the process crashed"},
+	6:  {"SIGABRT", "aborted (SIGABRT) — e.g. an assertion failure or panic"},
+	1:  {"SIGHUP", "hangup (SIGHUP) — controlling terminal closed"},
+	13: {"SIGPIPE", "broken pipe (SIGPIPE) — wrote to a closed pipe/socket"},
+}
+
+// Interpret returns signal Info for a 128+N exit code, or nil when the code
+// is a plain application exit (including 0). Returning nil keeps callers
+// additive: no signal field is emitted for ordinary failures.
+func Interpret(exitCode int) *Info {
+	if exitCode <= 128 || exitCode > 165 {
+		return nil
+	}
+	n := exitCode - 128
+	info := &Info{ExitCode: exitCode, SignalNo: n}
+	if k, ok := known[n]; ok {
+		info.Signal = k.name
+		info.Meaning = k.meaning
+	} else {
+		info.Signal = fmt.Sprintf("SIG%d", n)
+		info.Meaning = fmt.Sprintf("terminated by signal %d", n)
+	}
+	return info
+}
+
+// Annotate returns a short human-readable suffix for an exit code, e.g.
+// " — SIGINT" for 130, or "" when the code carries no signal meaning.
+func Annotate(exitCode int) string {
+	if info := Interpret(exitCode); info != nil {
+		return " — " + info.Signal
+	}
+	return ""
+}

--- a/pkg/signals/signals_test.go
+++ b/pkg/signals/signals_test.go
@@ -1,0 +1,50 @@
+package signals
+
+import "testing"
+
+func TestInterpret(t *testing.T) {
+	cases := []struct {
+		code       int
+		wantNil    bool
+		wantSignal string
+		wantNo     int
+	}{
+		{0, true, "", 0},
+		{1, true, "", 0},   // plain app failure, not a signal
+		{128, true, "", 0}, // boundary: not 128+N
+		{130, false, "SIGINT", 2},
+		{137, false, "SIGKILL", 9},
+		{143, false, "SIGTERM", 15},
+		{139, false, "SIGSEGV", 11},
+		{134, false, "SIGABRT", 6},
+		{200, true, "", 0}, // above the signal range
+	}
+	for _, c := range cases {
+		got := Interpret(c.code)
+		if c.wantNil {
+			if got != nil {
+				t.Errorf("Interpret(%d) = %+v, want nil", c.code, got)
+			}
+			continue
+		}
+		if got == nil {
+			t.Errorf("Interpret(%d) = nil, want %s", c.code, c.wantSignal)
+			continue
+		}
+		if got.Signal != c.wantSignal || got.SignalNo != c.wantNo || got.ExitCode != c.code {
+			t.Errorf("Interpret(%d) = %+v, want signal=%s no=%d", c.code, got, c.wantSignal, c.wantNo)
+		}
+		if got.Meaning == "" {
+			t.Errorf("Interpret(%d) has empty meaning", c.code)
+		}
+	}
+}
+
+func TestAnnotate(t *testing.T) {
+	if got := Annotate(130); got != " — SIGINT" {
+		t.Errorf("Annotate(130) = %q, want %q", got, " — SIGINT")
+	}
+	if got := Annotate(1); got != "" {
+		t.Errorf("Annotate(1) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
A tool exiting **130** (SIGINT) makes the agent mark a job `STOPPED` instead of `FAILED`, so failure notifications never fire. The code shows only in the raw jsonl log, not the UI — root cause behind support case renderedtext/tasks#9851.

Adds `pkg/signals` to interpret `128+N` exit codes. Additive — the raw `exit_code` is never touched:

| Surface | After |
|---|---|
| `job log` (table) | `[exit code: 130 — SIGINT]` |
| `job log` (json) | `exit_code: 130` + `signal: {signal, signal_no, meaning}` |
| `diagnose` | per-job `signal` + top-level `stop_reason` |

Covers 130 SIGINT · 137 SIGKILL/OOM · 143 SIGTERM · 139 SIGSEGV · 134 SIGABRT.

Tested with unit tests + end-to-end against a real stopped job.
