### PR TITLE
feat: flaky + insights commands (CLI + MCP)

### DIFF
--- a/cmd/flaky.go
+++ b/cmd/flaky.go
@@ -54,7 +54,7 @@ func (f flakyFilters) toValues() url.Values {
 func flakyListParams(f flakyFilters, page, pageSize int, sortField, sortDir string) url.Values {
 	v := f.toValues()
 	v.Set("page", fmt.Sprintf("%d", page))
-	v.Set("page_size", fmt.Sprintf("%d", pageSize))
+	v.Set("page_size", fmt.Sprintf("%d", clampPageSize(pageSize)))
 	if sortField != "" {
 		v.Set("sort_field", sortField)
 	}
@@ -67,8 +67,20 @@ func flakyListParams(f flakyFilters, page, pageSize int, sortField, sortDir stri
 func pagedFilterParams(f flakyFilters, page, pageSize int) url.Values {
 	v := f.toValues()
 	v.Set("page", fmt.Sprintf("%d", page))
-	v.Set("page_size", fmt.Sprintf("%d", pageSize))
+	v.Set("page_size", fmt.Sprintf("%d", clampPageSize(pageSize)))
 	return v
+}
+
+// clampPageSize bounds a requested page size to [1, 100] (the server also caps at 100).
+func clampPageSize(n int) int {
+	switch {
+	case n > 100:
+		return 100
+	case n < 1:
+		return 1
+	default:
+		return n
+	}
 }
 
 func addFilterFlags(cmd *cobra.Command, f *flakyFilters) {
@@ -116,7 +128,10 @@ func emitJSON(resp *client.Response) error {
 		return fmt.Errorf("API returned %d", resp.StatusCode)
 	}
 	var result any
-	json.Unmarshal(resp.Body, &result)
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		output.Error("parse_error", fmt.Sprintf("failed to decode response: %v", err), 1)
+		return err
+	}
 	output.Result(result)
 	return nil
 }

--- a/cmd/flaky.go
+++ b/cmd/flaky.go
@@ -1,0 +1,291 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/semaphoreio/sem-ai/pkg/client"
+	"github.com/semaphoreio/sem-ai/pkg/config"
+	"github.com/semaphoreio/sem-ai/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+var flakyCmd = &cobra.Command{
+	Use:   "flaky",
+	Short: "History-backed flaky-test signals (Superjerry) for a project",
+	Long: `Query a project's flaky-test history from the Test Results API.
+
+This is the server-backed history view (weeks of disruptions, pass-rate, labels).
+For a quick single-pipeline snapshot from junit artifacts, see 'sem-ai test flaky'.`,
+}
+
+type flakyFilters struct {
+	Branch, CommitSha, TestName, Group, File, Suite, Runner string
+	Label, Resolved, Scheduled, Age, PassRate, Disruptions  string
+	DateFrom, DateTo                                        string
+}
+
+func (f flakyFilters) toValues() url.Values {
+	v := url.Values{}
+	add := func(key, val string) {
+		if val != "" {
+			v.Set(key, val)
+		}
+	}
+	add("branch", f.Branch)
+	add("commit_sha", f.CommitSha)
+	add("test_name", f.TestName)
+	add("group", f.Group)
+	add("file", f.File)
+	add("suite", f.Suite)
+	add("runner", f.Runner)
+	add("label", f.Label)
+	add("resolved", f.Resolved)
+	add("scheduled", f.Scheduled)
+	add("age", f.Age)
+	add("pass_rate", f.PassRate)
+	add("disruptions", f.Disruptions)
+	add("date_from", f.DateFrom)
+	add("date_to", f.DateTo)
+	return v
+}
+
+func flakyListParams(f flakyFilters, page, pageSize int, sortField, sortDir string) url.Values {
+	v := f.toValues()
+	v.Set("page", fmt.Sprintf("%d", page))
+	v.Set("page_size", fmt.Sprintf("%d", pageSize))
+	if sortField != "" {
+		v.Set("sort_field", sortField)
+	}
+	if sortDir != "" {
+		v.Set("sort_dir", sortDir)
+	}
+	return v
+}
+
+func pagedFilterParams(f flakyFilters, page, pageSize int) url.Values {
+	v := f.toValues()
+	v.Set("page", fmt.Sprintf("%d", page))
+	v.Set("page_size", fmt.Sprintf("%d", pageSize))
+	return v
+}
+
+func addFilterFlags(cmd *cobra.Command, f *flakyFilters) {
+	fl := cmd.Flags()
+	fl.StringVar(&f.Branch, "branch", "", "filter by git branch (wildcards allowed)")
+	fl.StringVar(&f.CommitSha, "commit-sha", "", "filter by commit SHA")
+	fl.StringVar(&f.TestName, "test-name", "", "filter by test name")
+	fl.StringVar(&f.Group, "group", "", "filter by test group")
+	fl.StringVar(&f.File, "file", "", "filter by test file")
+	fl.StringVar(&f.Suite, "suite", "", "filter by test suite")
+	fl.StringVar(&f.Runner, "runner", "", "filter by test runner/framework")
+	fl.StringVar(&f.Label, "label", "", "filter by label(s), comma-separated")
+	fl.StringVar(&f.Resolved, "resolved", "", "filter by resolved status (true|false)")
+	fl.StringVar(&f.Scheduled, "scheduled", "", "filter by scheduled status (true|false)")
+	fl.StringVar(&f.Age, "age", "", "filter by age in days, with operator e.g. >=30")
+	fl.StringVar(&f.PassRate, "pass-rate", "", "filter by pass rate %, with operator e.g. <50")
+	fl.StringVar(&f.Disruptions, "disruptions", "", "filter by disruption count, with operator e.g. >5")
+	fl.StringVar(&f.DateFrom, "date-from", "", "start date YYYY-MM-DD or now-Nd")
+	fl.StringVar(&f.DateTo, "date-to", "", "end date YYYY-MM-DD or now+Nd")
+}
+
+func flakyResourcePath(projectID, testID, sub string) string {
+	p := fmt.Sprintf("projects/%s/test_results/flaky_tests/%s", projectID, testID)
+	if sub != "" {
+		p += "/" + sub
+	}
+	return p
+}
+
+func flakyTrendsPath(projectID, metric string) (string, error) {
+	switch metric {
+	case "", "flaky":
+		return fmt.Sprintf("projects/%s/test_results/flaky_history", projectID), nil
+	case "disruptions":
+		return fmt.Sprintf("projects/%s/test_results/disruption_history", projectID), nil
+	default:
+		return "", fmt.Errorf("invalid --metric %q (want flaky|disruptions)", metric)
+	}
+}
+
+// emitJSON decodes a 200 body and prints it; otherwise emits a structured error.
+func emitJSON(resp *client.Response) error {
+	if resp.StatusCode != 200 {
+		output.Error("api_error", fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body)), resp.StatusCode)
+		return fmt.Errorf("API returned %d", resp.StatusCode)
+	}
+	var result any
+	json.Unmarshal(resp.Body, &result)
+	output.Result(result)
+	return nil
+}
+
+// ---- flaky list ----
+
+var (
+	flakyListProject  string
+	flakyListPage     int
+	flakyListPageSize int
+	flakyListSortF    string
+	flakyListSortD    string
+	flakyListFilters  flakyFilters
+)
+
+var flakyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List flaky tests for a project",
+	Example: `  sem-ai flaky list --project my-project
+  sem-ai flaky list --project my-project --branch main --resolved false
+  sem-ai flaky list --project my-project --pass-rate "<80" --sort-field pass_rate --sort-dir asc`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured — run 'sem-ai connect' first")
+		}
+		projectID, err := resolveProjectID(flakyListProject)
+		if err != nil {
+			output.Error("project_error", err.Error(), 1)
+			return err
+		}
+		params := flakyListParams(flakyListFilters, flakyListPage, flakyListPageSize, flakyListSortF, flakyListSortD)
+
+		c := client.New()
+		resp, err := c.ListWithParams(fmt.Sprintf("projects/%s/test_results/flaky_tests", projectID), params)
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		return emitJSON(resp)
+	},
+}
+
+// ---- flaky show ----
+
+var (
+	flakyShowProject string
+	flakyShowFilters flakyFilters
+)
+
+var flakyShowCmd = &cobra.Command{
+	Use:     "show <test_id>",
+	Short:   "Show details for a single flaky test (per-context pass rate, p95, disruptions)",
+	Args:    cobra.ExactArgs(1),
+	Example: `  sem-ai flaky show 3f2a... --project my-project`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured — run 'sem-ai connect' first")
+		}
+		projectID, err := resolveProjectID(flakyShowProject)
+		if err != nil {
+			output.Error("project_error", err.Error(), 1)
+			return err
+		}
+		c := client.New()
+		resp, err := c.ListWithParams(flakyResourcePath(projectID, args[0], ""), flakyShowFilters.toValues())
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		return emitJSON(resp)
+	},
+}
+
+// ---- flaky disruptions ----
+
+var (
+	flakyDisrProject  string
+	flakyDisrPage     int
+	flakyDisrPageSize int
+	flakyDisrFilters  flakyFilters
+)
+
+var flakyDisruptionsCmd = &cobra.Command{
+	Use:     "disruptions <test_id>",
+	Short:   "List individual disruption occurrences for a flaky test",
+	Args:    cobra.ExactArgs(1),
+	Example: `  sem-ai flaky disruptions 3f2a... --project my-project --page-size 50`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured — run 'sem-ai connect' first")
+		}
+		projectID, err := resolveProjectID(flakyDisrProject)
+		if err != nil {
+			output.Error("project_error", err.Error(), 1)
+			return err
+		}
+		c := client.New()
+		resp, err := c.ListWithParams(
+			flakyResourcePath(projectID, args[0], "disruptions"),
+			pagedFilterParams(flakyDisrFilters, flakyDisrPage, flakyDisrPageSize),
+		)
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		return emitJSON(resp)
+	},
+}
+
+// ---- flaky trends ----
+
+var (
+	flakyTrendsProject string
+	flakyTrendsMetric  string
+	flakyTrendsFilters flakyFilters
+)
+
+var flakyTrendsCmd = &cobra.Command{
+	Use:   "trends",
+	Short: "Project-level flaky/disruption count time series (day, count)",
+	Example: `  sem-ai flaky trends --project my-project
+  sem-ai flaky trends --project my-project --metric disruptions --branch main`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured — run 'sem-ai connect' first")
+		}
+		projectID, err := resolveProjectID(flakyTrendsProject)
+		if err != nil {
+			output.Error("project_error", err.Error(), 1)
+			return err
+		}
+		path, err := flakyTrendsPath(projectID, flakyTrendsMetric)
+		if err != nil {
+			output.Error("usage_error", err.Error(), 1)
+			return err
+		}
+		c := client.New()
+		resp, err := c.ListWithParams(path, flakyTrendsFilters.toValues())
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		return emitJSON(resp)
+	},
+}
+
+func init() {
+	flakyListCmd.Flags().StringVar(&flakyListProject, "project", "", "project name or ID (required)")
+	flakyListCmd.Flags().IntVar(&flakyListPage, "page", 1, "page number")
+	flakyListCmd.Flags().IntVar(&flakyListPageSize, "page-size", 20, "results per page")
+	flakyListCmd.Flags().StringVar(&flakyListSortF, "sort-field", "", "sort field (e.g. total_disruptions_count, pass_rate)")
+	flakyListCmd.Flags().StringVar(&flakyListSortD, "sort-dir", "", "sort direction (asc|desc)")
+	addFilterFlags(flakyListCmd, &flakyListFilters)
+
+	flakyShowCmd.Flags().StringVar(&flakyShowProject, "project", "", "project name or ID (required)")
+	addFilterFlags(flakyShowCmd, &flakyShowFilters)
+
+	flakyDisruptionsCmd.Flags().StringVar(&flakyDisrProject, "project", "", "project name or ID (required)")
+	flakyDisruptionsCmd.Flags().IntVar(&flakyDisrPage, "page", 1, "page number")
+	flakyDisruptionsCmd.Flags().IntVar(&flakyDisrPageSize, "page-size", 10, "results per page")
+	addFilterFlags(flakyDisruptionsCmd, &flakyDisrFilters)
+
+	flakyTrendsCmd.Flags().StringVar(&flakyTrendsProject, "project", "", "project name or ID (required)")
+	flakyTrendsCmd.Flags().StringVar(&flakyTrendsMetric, "metric", "flaky", "series: flaky|disruptions")
+	addFilterFlags(flakyTrendsCmd, &flakyTrendsFilters)
+
+	flakyCmd.AddCommand(flakyListCmd)
+	flakyCmd.AddCommand(flakyShowCmd)
+	flakyCmd.AddCommand(flakyDisruptionsCmd)
+	flakyCmd.AddCommand(flakyTrendsCmd)
+	rootCmd.AddCommand(flakyCmd)
+}

--- a/cmd/flaky_test.go
+++ b/cmd/flaky_test.go
@@ -82,3 +82,19 @@ func TestFlakyTrendsEndpoint(t *testing.T) {
 		t.Error("invalid metric must error")
 	}
 }
+
+func TestClampPageSize(t *testing.T) {
+	cases := map[int]int{100000: 100, 101: 100, 100: 100, 50: 50, 1: 1, 0: 1, -5: 1}
+	for in, want := range cases {
+		if got := clampPageSize(in); got != want {
+			t.Errorf("clampPageSize(%d) = %d, want %d", in, got, want)
+		}
+	}
+	// and it flows through the param builders
+	if v := flakyListParams(flakyFilters{}, 1, 100000, "", ""); v.Get("page_size") != "100" {
+		t.Errorf("flakyListParams page_size not clamped: %q", v.Get("page_size"))
+	}
+	if v := pagedFilterParams(flakyFilters{}, 1, 100000); v.Get("page_size") != "100" {
+		t.Errorf("pagedFilterParams page_size not clamped: %q", v.Get("page_size"))
+	}
+}

--- a/cmd/flaky_test.go
+++ b/cmd/flaky_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestFlakyFilterParams_mapsAllowlist(t *testing.T) {
+	f := flakyFilters{
+		Branch: "main", TestName: "Login Test", Label: "flaky,slow",
+		Resolved: "false", PassRate: ">=80", DateFrom: "2026-01-01",
+	}
+	got := f.toValues()
+
+	checks := map[string]string{
+		"branch":    "main",
+		"test_name": "Login Test",
+		"label":     "flaky,slow",
+		"resolved":  "false",
+		"pass_rate": ">=80",
+		"date_from": "2026-01-01",
+	}
+	for k, want := range checks {
+		if got.Get(k) != want {
+			t.Errorf("param %q = %q, want %q", k, got.Get(k), want)
+		}
+	}
+}
+
+func TestFlakyFilterParams_omitsEmpty(t *testing.T) {
+	got := flakyFilters{Branch: "main"}.toValues()
+	if _, ok := got["test_name"]; ok {
+		t.Error("empty test_name must not be sent")
+	}
+	if len(got) != 1 {
+		t.Errorf("only non-empty filters sent, got %v", got)
+	}
+}
+
+func TestFlakyListParams_addsPagingAndSort(t *testing.T) {
+	got := flakyListParams(flakyFilters{Branch: "main"}, 2, 50, "pass_rate", "asc")
+	if got.Get("page") != "2" || got.Get("page_size") != "50" {
+		t.Errorf("paging not set: %v", got)
+	}
+	if got.Get("sort_field") != "pass_rate" || got.Get("sort_dir") != "asc" {
+		t.Errorf("sort not set: %v", got)
+	}
+	if got.Get("branch") != "main" {
+		t.Error("filters must be merged into list params")
+	}
+}
+
+func TestFlakyResourcePath(t *testing.T) {
+	got := flakyResourcePath("proj-1", "test-9", "disruptions")
+	want := "projects/proj-1/test_results/flaky_tests/test-9/disruptions"
+	if got != want {
+		t.Errorf("path = %q, want %q", got, want)
+	}
+	if base := flakyResourcePath("proj-1", "test-9", ""); base != "projects/proj-1/test_results/flaky_tests/test-9" {
+		t.Errorf("base path wrong: %q", base)
+	}
+}
+
+func TestFlakyDisruptionsParams(t *testing.T) {
+	v := pagedFilterParams(flakyFilters{Branch: "main"}, 3, 25)
+	if v.Get("page") != "3" || v.Get("page_size") != "25" || v.Get("branch") != "main" {
+		t.Errorf("disruptions params wrong: %v", v)
+	}
+}
+
+func TestFlakyTrendsEndpoint(t *testing.T) {
+	cases := map[string]string{
+		"flaky":       "projects/p/test_results/flaky_history",
+		"disruptions": "projects/p/test_results/disruption_history",
+		"":            "projects/p/test_results/flaky_history",
+	}
+	for metric, want := range cases {
+		if got, _ := flakyTrendsPath("p", metric); got != want {
+			t.Errorf("metric %q -> %q, want %q", metric, got, want)
+		}
+	}
+	if _, err := flakyTrendsPath("p", "bogus"); err == nil {
+		t.Error("invalid metric must error")
+	}
+}

--- a/cmd/insights.go
+++ b/cmd/insights.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/semaphoreio/sem-ai/pkg/client"
+	"github.com/semaphoreio/sem-ai/pkg/config"
+	"github.com/semaphoreio/sem-ai/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+var insightsCmd = &cobra.Command{
+	Use:   "insights",
+	Short: "Pipeline insights (Velocity): performance, reliability, frequency",
+}
+
+func insightsParams(pipelineFile, branch, from, to, aggregate string) url.Values {
+	v := url.Values{}
+	v.Set("pipeline_file", pipelineFile)
+	if branch != "" {
+		v.Set("branch", branch)
+	}
+	if from != "" {
+		v.Set("from", from)
+	}
+	if to != "" {
+		v.Set("to", to)
+	}
+	if aggregate != "" {
+		v.Set("aggregate", aggregate)
+	}
+	return v
+}
+
+type insightsFlags struct {
+	project, pipelineFile, branch, from, to, aggregate string
+}
+
+func runInsights(metric string, f *insightsFlags) error {
+	if !config.IsConfigured() {
+		return fmt.Errorf("not configured — run 'sem-ai connect' first")
+	}
+	if f.pipelineFile == "" {
+		output.Error("usage_error", "--pipeline-file is required", 1)
+		return fmt.Errorf("--pipeline-file is required")
+	}
+	projectID, err := resolveProjectID(f.project)
+	if err != nil {
+		output.Error("project_error", err.Error(), 1)
+		return err
+	}
+	c := client.New()
+	resp, err := c.ListWithParams(
+		fmt.Sprintf("projects/%s/insights/%s", projectID, metric),
+		insightsParams(f.pipelineFile, f.branch, f.from, f.to, f.aggregate),
+	)
+	if err != nil {
+		output.Error("api_error", err.Error(), 1)
+		return err
+	}
+	return emitJSON(resp)
+}
+
+func newInsightsSubCmd(metric, short string) (*cobra.Command, *insightsFlags) {
+	f := &insightsFlags{}
+	cmd := &cobra.Command{
+		Use:     metric,
+		Short:   short,
+		Example: fmt.Sprintf("  sem-ai insights %s --project my-project --pipeline-file .semaphore/semaphore.yml --branch main", metric),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInsights(metric, f)
+		},
+	}
+	cmd.Flags().StringVar(&f.project, "project", "", "project name or ID (required)")
+	cmd.Flags().StringVar(&f.pipelineFile, "pipeline-file", "", "pipeline YAML path (required, e.g. .semaphore/semaphore.yml)")
+	cmd.Flags().StringVar(&f.branch, "branch", "", "branch name")
+	cmd.Flags().StringVar(&f.from, "from", "", "start date YYYY-MM-DD")
+	cmd.Flags().StringVar(&f.to, "to", "", "end date YYYY-MM-DD")
+	cmd.Flags().StringVar(&f.aggregate, "aggregate", "daily", "aggregation: daily|range")
+	return cmd, f
+}
+
+func init() {
+	perf, _ := newInsightsSubCmd("performance", "Pipeline duration metrics (mean/median/p95 seconds)")
+	reliab, _ := newInsightsSubCmd("reliability", "Pipeline pass/fail counts")
+	freq, _ := newInsightsSubCmd("frequency", "Pipeline run frequency")
+
+	insightsCmd.AddCommand(perf)
+	insightsCmd.AddCommand(reliab)
+	insightsCmd.AddCommand(freq)
+	rootCmd.AddCommand(insightsCmd)
+}

--- a/cmd/insights_test.go
+++ b/cmd/insights_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import "testing"
+
+func TestInsightsParams(t *testing.T) {
+	v := insightsParams("ci.yml", "main", "2026-01-01", "2026-01-31", "range")
+	if v.Get("pipeline_file") != "ci.yml" || v.Get("branch") != "main" {
+		t.Errorf("base params wrong: %v", v)
+	}
+	if v.Get("from") != "2026-01-01" || v.Get("to") != "2026-01-31" || v.Get("aggregate") != "range" {
+		t.Errorf("date/aggregate wrong: %v", v)
+	}
+}
+
+func TestInsightsParams_omitsEmptyOptional(t *testing.T) {
+	v := insightsParams("ci.yml", "", "", "", "")
+	if v.Get("pipeline_file") != "ci.yml" {
+		t.Error("pipeline_file must be present")
+	}
+	for _, k := range []string{"branch", "from", "to", "aggregate"} {
+		if _, ok := v[k]; ok {
+			t.Errorf("empty %q must be omitted", k)
+		}
+	}
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -139,7 +139,11 @@ var testFlakyCmd = &cobra.Command{
 	Long: `Analyzes the last N workflows for a project and finds tests that
 sometimes pass and sometimes fail — i.e. flaky tests.
 
-Returns each flaky test with its pass/fail ratio across recent runs.`,
+Returns each flaky test with its pass/fail ratio across recent runs.
+
+This is a quick per-pipeline snapshot from junit artifacts (works even without
+the flaky-tests backend). For history-backed flaky data (weeks of disruptions,
+pass-rate, labels) use 'sem-ai flaky list'.`,
 	Example: `  sem-ai test flaky --project my-project
   sem-ai test flaky --project my-project --branch main --count 10`,
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## What

Adds two command groups that consume the new public-api `v1alpha` test-signals endpoints, surfaced to humans (CLI) and agents (auto-registered MCP tools):

- `sem-ai flaky list | show <test_id> | disruptions <test_id> | trends` — history-backed flaky-test data (Superjerry)
- `sem-ai insights performance | reliability | frequency` — pipeline metrics (Velocity)

All reads-only. Each leaf auto-registers as an MCP tool (`flaky_list`, `flaky_show`, `flaky_disruptions`, `flaky_trends`, `insights_performance`, `insights_reliability`, `insights_frequency`). The existing `test flaky` junit-snapshot heuristic is unchanged; its help now points at `flaky list` for real history.

## Notes

- Uses the default `v1alpha` client; 15 structured filter flags on the flaky commands; `page_size` clamped client-side.
- `emitJSON` surfaces decode errors instead of printing `null` on a malformed body.
- Depends on the matching public-api `v1alpha` endpoints (separate server-side change).

Helps #602 (share failed tests with AI agents) and #890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
