### PR TITLE
feat: zero-context sem-ai status (autodetect project, SHA/PR-precise, --exit-code) + awareness hook + skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ codex plugin marketplace add semaphoreio/sem-ai
 codex plugin add sem-ai@semaphoreio
 ```
 
-The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox) into your host.
+The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox, watch-after-push) into your host.
 
 Claude Code refreshes registered marketplaces at session start, picks up the new plugin version, and applies it automatically — there is no manifest flag to set for this. To force an immediate refresh:
 
@@ -77,6 +77,23 @@ User-invocable skills can be triggered directly with a namespaced slash command 
 | `/sem-ai:gha-to-semaphore` | Translate only — same procedure as `init`'s translate path, scoped to converting `.github/workflows/*` |
 
 Other skills are loaded automatically when their description keywords match the user's prompt; the slash commands above are explicit triggers for the most common entry points.
+
+### Skills-only install (`npx skills`, any agent)
+
+Prefer the full plugin above on Claude Code / Codex — it also wires the MCP server and the `SessionStart` hooks. For other agents (Cursor, OpenCode, …) or when you want just the skill instructions, use the cross-agent [`skills`](https://github.com/vercel-labs/skills) installer. It reads sem-ai's `.claude-plugin/marketplace.json` manifest, so it finds the bundle even though the skills live under `assets/plugin/skills/`:
+
+```sh
+npx skills add semaphoreio/sem-ai --list             # list available skills
+npx skills add semaphoreio/sem-ai --all              # install all of them
+npx skills add semaphoreio/sem-ai --skill semaphore-ci --skill watch-after-push
+npx skills add semaphoreio/sem-ai --all -g           # user-level (every repo)
+npx skills add semaphoreio/sem-ai --all --agent cursor opencode
+```
+
+Two caveats:
+
+- **Skills only.** `npx skills` installs `SKILL.md` files — not the MCP server and not the `SessionStart` hooks (release-update check, Semaphore-repo awareness). For those, use the plugin install above.
+- **The CLI is a prerequisite.** Every skill shells out to `sem-ai`; install the binary first (see [Install](#install)) and run `sem-ai connect`. `npx skills` installs instructions, not the CLI.
 
 ## Updates
 

--- a/assets/plugin/hooks/detect-semaphore.sh
+++ b/assets/plugin/hooks/detect-semaphore.sh
@@ -11,7 +11,7 @@ set -uo pipefail
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] && [ -d "$root/.semaphore" ] || exit 0
 
-base="This repository is built on Semaphore CI (.semaphore/ present). For any CI, pipeline, test-result, deploy, or build-status question, use sem-ai (the semaphore-ci skill) — do not assume GitHub Actions. Prefer 'sem-ai status' (it auto-detects the project + branch from git) over 'gh pr checks' for the is-it-green check: it reads the same Semaphore status and keeps the failure drill ('sem-ai diagnose <workflow-id>') one tool away. After pushing, follow the run with the watch-after-push skill."
+base="This repository runs its CI on Semaphore (.semaphore/ present), connected to its git host (GitHub, GitLab, or Bitbucket). For any CI, pipeline, test-result, deploy, or build-status question, prefer sem-ai (the semaphore-ci skill): 'sem-ai status' auto-detects the project + branch from git and is the is-it-green check. The git host's own checks (e.g. 'gh pr checks') mirror the same Semaphore result and are a fine fallback when sem-ai isn't connected — sem-ai is preferred because it keeps the failure drill ('sem-ai diagnose <workflow-id>') one tool away. After pushing, follow the run with the watch-after-push skill."
 
 # Live current-branch CI state — bounded so it can never stall session start.
 # `sem-ai status` auto-detects project + branch and pins the current HEAD commit.

--- a/assets/plugin/hooks/detect-semaphore.sh
+++ b/assets/plugin/hooks/detect-semaphore.sh
@@ -1,11 +1,44 @@
 #!/usr/bin/env bash
 # SessionStart hook: if the working repo is Semaphore-managed (.semaphore/ present),
-# tell the agent to drive CI through sem-ai instead of guessing GitHub Actions.
-# Stays silent (exit 0, no output) for non-Semaphore repos.
+# (1) tell the agent to drive CI through sem-ai instead of guessing GitHub Actions, and
+# (2) surface the current branch's live CI state (project + workflow + result) so the
+# agent starts oriented without spending a turn resolving it.
+#
+# Best-effort and silent: emits nothing for non-Semaphore repos, and degrades to the
+# static guidance if the live status lookup is unavailable, unconfigured, or slow.
 set -uo pipefail
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] && [ -d "$root/.semaphore" ] || exit 0
 
-printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' \
-  "This repository is built on Semaphore CI (.semaphore/ present). For any CI, pipeline, test-result, deploy, or build-status question, use sem-ai (the semaphore-ci skill) — do not assume GitHub Actions. After pushing commits, watch the triggered run to completion via the watch-after-push skill. The Semaphore project auto-detects from the git remote."
+base="This repository is built on Semaphore CI (.semaphore/ present). For any CI, pipeline, test-result, deploy, or build-status question, use sem-ai (the semaphore-ci skill) — do not assume GitHub Actions. Prefer 'sem-ai status' (it auto-detects the project + branch from git) over 'gh pr checks' for the is-it-green check: it reads the same Semaphore status and keeps the failure drill ('sem-ai diagnose <workflow-id>') one tool away. After pushing, follow the run with the watch-after-push skill."
+
+# Live current-branch CI state — bounded so it can never stall session start.
+# `sem-ai status` auto-detects project + branch and pins the current HEAD commit.
+live=""
+if command -v sem-ai >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  s="$(perl -e 'alarm shift; exec @ARGV' 8 sem-ai status --format json 2>/dev/null || true)"
+  if [ -n "$s" ]; then
+    live="$(printf '%s' "$s" | jq -r '
+      if .multiple_projects == true then
+        "Current branch maps to multiple Semaphore projects (" + (.projects | map(.project) | join(", ")) + ") — pass --project to pick one."
+      elif .status == "no_workflows" then
+        "No CI workflow for the current branch/commit yet — push to trigger one."
+      elif .workflow_id then
+        "Current CI: project=" + (.project // "?") + " branch=" + (.branch // "?")
+        + " state=" + (.pipeline.state // "?")
+        + (if (.pipeline.result // "") != "" then "/" + .pipeline.result else "" end)
+        + " (workflow " + .workflow_id + "). Recheck with \"sem-ai status\"; drill failures with \"sem-ai diagnose " + .workflow_id + "\"."
+      else "" end' 2>/dev/null || true)"
+  fi
+fi
+
+ctx="$base"
+[ -n "$live" ] && ctx="$base $live"
+
+# Emit JSON with jq when available (safe escaping); fall back to a plain printf.
+if command -v jq >/dev/null 2>&1; then
+  printf '%s' "$ctx" | jq -Rs '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:.}}'
+else
+  printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$base"
+fi

--- a/assets/plugin/hooks/detect-semaphore.sh
+++ b/assets/plugin/hooks/detect-semaphore.sh
@@ -15,9 +15,21 @@ base="This repository is built on Semaphore CI (.semaphore/ present). For any CI
 
 # Live current-branch CI state — bounded so it can never stall session start.
 # `sem-ai status` auto-detects project + branch and pins the current HEAD commit.
+# Timeout is plain bash (background job + watchdog) — no perl/timeout dependency,
+# so the hook keeps working even where those aren't installed.
 live=""
 if command -v sem-ai >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
-  s="$(perl -e 'alarm shift; exec @ARGV' 8 sem-ai status --format json 2>/dev/null || true)"
+  s=""
+  tmp="$(mktemp 2>/dev/null || echo "/tmp/sem-ai-status.$$")"
+  sem-ai status --format json >"$tmp" 2>/dev/null &
+  sa_pid=$!
+  ( sleep 8; kill "$sa_pid" 2>/dev/null ) >/dev/null 2>&1 &
+  wd_pid=$!
+  disown "$wd_pid" 2>/dev/null || true   # don't announce the watchdog when we kill it
+  wait "$sa_pid" 2>/dev/null
+  kill "$wd_pid" 2>/dev/null || true
+  s="$(cat "$tmp" 2>/dev/null || true)"
+  rm -f "$tmp"
   if [ -n "$s" ]; then
     live="$(printf '%s' "$s" | jq -r '
       if .multiple_projects == true then

--- a/assets/plugin/hooks/detect-semaphore.sh
+++ b/assets/plugin/hooks/detect-semaphore.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SessionStart hook: if the working repo is Semaphore-managed (.semaphore/ present),
+# tell the agent to drive CI through sem-ai instead of guessing GitHub Actions.
+# Stays silent (exit 0, no output) for non-Semaphore repos.
+set -uo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$root" ] && [ -d "$root/.semaphore" ] || exit 0
+
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' \
+  "This repository is built on Semaphore CI (.semaphore/ present). For any CI, pipeline, test-result, deploy, or build-status question, use sem-ai (the semaphore-ci skill) — do not assume GitHub Actions. After pushing commits, watch the triggered run to completion via the watch-after-push skill. The Semaphore project auto-detects from the git remote."

--- a/assets/plugin/hooks/hooks.json
+++ b/assets/plugin/hooks/hooks.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "command -v sem-ai >/dev/null 2>&1 && sem-ai version --hook || printf '{\"systemMessage\": \"sem-ai binary not found on PATH. Install: curl -fsSL https://raw.githubusercontent.com/semaphoreio/sem-ai/main/install.sh | sh\"}\\n'",
             "timeout": 4
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/detect-semaphore.sh\"",
+            "timeout": 4
           }
         ]
       }

--- a/assets/plugin/hooks/hooks.json
+++ b/assets/plugin/hooks/hooks.json
@@ -12,7 +12,7 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/detect-semaphore.sh\"",
-            "timeout": 4
+            "timeout": 12
           }
         ]
       }

--- a/assets/plugin/skills/debug-pipeline/SKILL.md
+++ b/assets/plugin/skills/debug-pipeline/SKILL.md
@@ -12,7 +12,7 @@ user-invocable: false
 sem-ai diagnose <workflow-id>
 # or auto-detect from git:
 sem-ai diagnose
-sem-ai diagnose --project my-app --branch main
+sem-ai diagnose --project my-app --branch main  # --project/--branch optional, auto-detected from origin + HEAD
 ```
 
 Returns: pipeline result, failed blocks, failed jobs with log tails AND parsed test results (file:line:message).
@@ -21,7 +21,7 @@ Returns: pipeline result, failed blocks, failed jobs with log tails AND parsed t
 
 ### 1. Find the workflow
 ```bash
-sem-ai workflow list --project my-app --branch feature-x
+sem-ai workflow list --branch feature-x  # --project/--branch optional, auto-detected from origin + HEAD
 ```
 
 ### 2. See pipeline structure
@@ -59,7 +59,7 @@ sem-ai troubleshoot job <id>
 
 ### 6. Check if flaky
 ```bash
-sem-ai test flaky --project my-app --count 10
+sem-ai test flaky --count 10  # --project optional, auto-detected from origin
 ```
 
 ## After fixing
@@ -70,6 +70,8 @@ sem-ai rerun-failed <pipeline-id>    # rebuild failed blocks only
 sem-ai watch <new-workflow-id>       # wait for completion
 sem-ai test summary --pipeline <id>  # verify
 ```
+
+`sem-ai watch <id>` is for when you already hold the id from `workflow rerun` output. To re-find and watch the rerun for your *exact* commit (e.g. after pushing the fix), use the **watch-after-push** pattern: find the run by `commit_sha`, then `sem-ai watch` it.
 
 ## Common patterns
 

--- a/assets/plugin/skills/gha-to-semaphore/SKILL.md
+++ b/assets/plugin/skills/gha-to-semaphore/SKILL.md
@@ -133,7 +133,7 @@ When invoked, do the following in order:
      - "Secrets required" — list created via `sem-ai secret create`
      - "Differences in behavior" — fail-fast dropped, runner image picked, PR-trigger config moved server-side, etc.
      - "Speed suggestions" — sharding candidates flagged in step 4
-9. **First run**: after merge, watch with `sem-ai workflow_list --project <name> --limit 1` and `sem-ai job_log` on any failure. Iterate.
+9. **First run**: after merge, hand off to `watch-after-push` — find the run by `commit_sha` and `sem-ai watch` it to completion (project auto-detects from `origin`; pass `--project` only to override or when the repo maps to multiple). On any failure, drill in with `sem-ai workflow list` and `sem-ai job log`. Iterate.
 
 ## PR body template
 

--- a/assets/plugin/skills/init/SKILL.md
+++ b/assets/plugin/skills/init/SKILL.md
@@ -122,8 +122,12 @@ sem-ai secret create <NAME> --env <NAME>=<value>
 
 ### Step 9 — Watch the first workflow
 
+Hand off to the `watch-after-push` skill: find the run for the pushed HEAD commit, then watch it to completion. `--project` auto-detects from the `origin` remote — pass it only to override or when the repo maps to multiple projects.
+
 ```bash
-sem-ai workflow list --project <name> --limit 1
+# Locate the run by the pushed HEAD commit, then watch it to green:
+sem-ai workflow list --limit 1   # confirm the run for the new commit; pass --project only to override
+sem-ai watch <wf>
 ```
 
 On failure: `sem-ai job log <job-id>`. Iterate fixes; surface any patterns worth feeding back as skill improvements.

--- a/assets/plugin/skills/project-health/SKILL.md
+++ b/assets/plugin/skills/project-health/SKILL.md
@@ -18,6 +18,7 @@ sem-ai status --project my-app --branch main
 sem-ai status --project my-app --pr 422
 sem-ai status   # auto-detects project + branch from git
 ```
+`status` pins the current HEAD commit (look for `"matched_by":"commit_sha"`). Add `--exit-code` for a poll-friendly loop (0=pass / 8=pending / 1=fail / 2=ambiguous / 3=none): `until sem-ai status --exit-code; do sleep 20; done` watches to green. Prefer this over `gh pr checks` for the is-it-green check — same Semaphore status, and the failure drill (`sem-ai diagnose <workflow-id>`) is one tool away.
 
 ## Recent workflows
 ```bash

--- a/assets/plugin/skills/semaphore-blocks/SKILL.md
+++ b/assets/plugin/skills/semaphore-blocks/SKILL.md
@@ -252,8 +252,10 @@ sem-ai pipeline show <pipeline-id>
 To find pipeline IDs for the current branch:
 
 ```
-sem-ai status --project <name> --branch <branch>
+sem-ai status        # --project and --branch are optional — auto-detected from origin + HEAD
 ```
+
+Pass `--project <name>` / `--branch <branch>` only to override the auto-detection (or when the repo maps to multiple Semaphore projects).
 
 To pre-flight YAML syntax before pushing:
 
@@ -262,6 +264,8 @@ sem-ai yaml validate --file .semaphore/semaphore.yml
 ```
 
 ### Polling a pipeline to terminal state — `result`, not `state`
+
+For the common "is it done / is it green" case, prefer `sem-ai watch <wf>` (blocks until terminal) or the poll-friendly `sem-ai status --exit-code` (`until sem-ai status --exit-code; do sleep 20; done` watches to green). The bespoke `until` loop below explains **why** those wait on `result` — keep it as the reference for callers building custom loops.
 
 When waiting for a pipeline to finish (e.g. background `until` loops watching first-run completion), check the **`result`** field, not `state`:
 

--- a/assets/plugin/skills/semaphore-ci/SKILL.md
+++ b/assets/plugin/skills/semaphore-ci/SKILL.md
@@ -43,6 +43,13 @@ sem-ai <any-command> --examples  # Usage examples for any command
 | List secrets | `sem-ai secret list` |
 | Flaky tests | `sem-ai test flaky --project <p>` |
 | Test locally in CI env | `sem-ai testbox warmup --project <p>` then `sem-ai testbox run --id <id> "cmd"` |
+| Watch CI after a push | `git push`, then `sem-ai watch <workflow-id>` (see `watch-after-push`) |
+
+## Project detection
+
+`sem-ai status`, `workflow list`, `health`, `diagnose`, `open`, and `analytics` auto-detect the project from the `origin` git remote (ssh or https) when `--project` is omitted — no need to pass it inside a checkout.
+
+Caveat: detection matches the remote URL against project `repo_url` and returns the **first match**. If several Semaphore projects point at the same git remote, it may pick the wrong one — pass `--project <name>` explicitly for multi-project repos. (To target a specific run regardless, filter `workflow list` by `commit_sha`; see the `watch-after-push` skill.)
 
 ## Sub-skills — load for deeper context
 
@@ -54,6 +61,7 @@ For detailed workflows with step-by-step examples, load the relevant sub-skill:
 - **Test analysis** → load `test-intelligence` — test results, flaky detection, frameworks
 - **Infrastructure** → load `manage-infra` — secrets, notifications, agents, tasks
 - **Monitoring** → load `project-health` — health checks, pass rates, trends
+- **After a push** → load `watch-after-push` — find the run for your commit and watch it to completion
 
 ## Safety
 

--- a/assets/plugin/skills/semaphore-ci/SKILL.md
+++ b/assets/plugin/skills/semaphore-ci/SKILL.md
@@ -46,7 +46,7 @@ sem-ai <any-command> --examples  # Usage examples for any command
 | Test locally in CI env | `sem-ai testbox warmup` (`--project` optional) then `sem-ai testbox run --id <id> "cmd"` |
 | Watch CI after a push | `git push`, then `sem-ai watch <workflow-id>` (see `watch-after-push`) |
 
-Prefer `sem-ai status` over `gh pr checks` for the is-it-green check — it reads the same Semaphore status and keeps the failure drill (`sem-ai diagnose <workflow-id>`) one tool away; `gh pr checks` is an acceptable fallback only when sem-ai isn't connected.
+For the is-it-green check, prefer `sem-ai status` — it keeps the failure drill (`sem-ai diagnose <workflow-id>`) one tool away. Your git host's own checks (`gh pr checks` on GitHub, or the GitLab/Bitbucket equivalent) mirror the same Semaphore result and are a fine fallback when sem-ai isn't connected — Semaphore connects to any of those hosts.
 
 ## Project detection
 

--- a/assets/plugin/skills/semaphore-ci/SKILL.md
+++ b/assets/plugin/skills/semaphore-ci/SKILL.md
@@ -29,7 +29,8 @@ sem-ai <any-command> --examples  # Usage examples for any command
 
 | Task | Command |
 |------|---------|
-| CI status | `sem-ai status --project <p> --branch <b>` |
+| CI status | `sem-ai status` (`--project`/`--branch` auto-detect; `--pr N` resolves a PR's workflow) |
+| Did my push pass? / watch CI to green | `sem-ai status` (or `until sem-ai status --exit-code; do sleep 20; done`); see `watch-after-push` |
 | Why did CI fail? | `sem-ai diagnose <workflow-id>` |
 | Project health | `sem-ai health --project <p>` |
 | Job logs | `sem-ai job log <job-id>` |
@@ -41,15 +42,17 @@ sem-ai <any-command> --examples  # Usage examples for any command
 | Validate YAML | `sem-ai yaml validate --file .semaphore/semaphore.yml` |
 | Server diagnostics | `sem-ai troubleshoot workflow <id>` |
 | List secrets | `sem-ai secret list` |
-| Flaky tests | `sem-ai test flaky --project <p>` |
-| Test locally in CI env | `sem-ai testbox warmup --project <p>` then `sem-ai testbox run --id <id> "cmd"` |
+| Flaky tests | `sem-ai test flaky` (`--project` optional; auto-detects) |
+| Test locally in CI env | `sem-ai testbox warmup` (`--project` optional) then `sem-ai testbox run --id <id> "cmd"` |
 | Watch CI after a push | `git push`, then `sem-ai watch <workflow-id>` (see `watch-after-push`) |
+
+Prefer `sem-ai status` over `gh pr checks` for the is-it-green check — it reads the same Semaphore status and keeps the failure drill (`sem-ai diagnose <workflow-id>`) one tool away; `gh pr checks` is an acceptable fallback only when sem-ai isn't connected.
 
 ## Project detection
 
-`sem-ai status`, `workflow list`, `health`, `diagnose`, `open`, and `analytics` auto-detect the project from the `origin` git remote (ssh or https) when `--project` is omitted — no need to pass it inside a checkout.
+`--project` is optional on all repo-scoped commands (status, workflow list/run, pipeline list, deploy targets/create, task list/create, test flaky, diagnose, health, open, analytics) — it auto-detects from the `origin` git remote (ssh or https) when omitted, so there's no need to pass it inside a checkout. `--branch` likewise auto-detects from HEAD; `sem-ai status` pins the current HEAD commit (`"matched_by":"commit_sha"`, falling back to `"latest_on_branch"`). Pass `--project`/`--branch` only to override.
 
-Caveat: detection matches the remote URL against project `repo_url` and returns the **first match**. If several Semaphore projects point at the same git remote, it may pick the wrong one — pass `--project <name>` explicitly for multi-project repos. (To target a specific run regardless, filter `workflow list` by `commit_sha`; see the `watch-after-push` skill.)
+Caveat: if the repo maps to **multiple** Semaphore projects, `sem-ai status` returns all of them (`"multiple_projects": true`) instead of guessing — pass `--project <name>` to pick one. (To target a specific run regardless, filter `workflow list` by `commit_sha`; see the `watch-after-push` skill.)
 
 ## Sub-skills — load for deeper context
 

--- a/assets/plugin/skills/testbox/SKILL.md
+++ b/assets/plugin/skills/testbox/SKILL.md
@@ -62,7 +62,7 @@ Or let it auto-expire after the duration/idle timeout.
 
 ```bash
 # Start of task
-TESTBOX=$(sem-ai testbox warmup --project my-app | jq -r '.testbox_id')
+TESTBOX=$(sem-ai testbox warmup | jq -r '.testbox_id')   # --project auto-detected from origin (pass it only to override)
 
 # Iterate on code
 # ... make changes ...
@@ -71,10 +71,9 @@ sem-ai testbox run --id $TESTBOX "go test ./..."
 sem-ai testbox run --id $TESTBOX "go test ./..."
 # tests pass!
 
-# Push and verify in real CI
+# After tests pass, push and verify in real CI — load the watch-after-push skill
+# (it finds the run for your exact commit_sha and watches it).
 git push
-sem-ai workflow list --project my-app --branch $(git branch --show-current)
-sem-ai watch <workflow-id>
 
 # Clean up
 sem-ai testbox stop --id $TESTBOX

--- a/assets/plugin/skills/watch-after-push/SKILL.md
+++ b/assets/plugin/skills/watch-after-push/SKILL.md
@@ -44,7 +44,8 @@ fi
 
 ## Notes
 
-- `sem-ai workflow list` and `sem-ai status` auto-detect the project from the `origin` remote. Pass `--project <name>` only when detection is wrong.
-- **Repo-URL collisions:** if more than one Semaphore project points at the same git remote, detection returns the *first* match. The `commit_sha` filter above keeps you on the right run regardless; if `watch` still tracks the wrong project, pin it with `--project`.
+- `sem-ai workflow list` and `sem-ai status` auto-detect the project from the `origin` remote. Pass `--project <name>` only to override, or when the repo maps to several projects.
+- **Shortcut:** `sem-ai status` already pins the current HEAD commit and returns `.workflow_id` — you can skip the loop above with `WF=$(sem-ai status --format json | jq -r .workflow_id)` once the run exists, or just poll `until sem-ai status --exit-code; do sleep 20; done` (0=pass, 8=pending, 1=fail).
+- **Repo-URL collisions:** if more than one Semaphore project points at the same git remote, detection returns *all* of them — `sem-ai status` reports `"multiple_projects": true` instead of guessing. The `commit_sha` filter above keeps the loop on the right run; if more than one project ran the same commit, pin the one you mean with `--project`.
 - `sem-ai watch` exits once every pipeline in the workflow reaches a terminal state, and reflects pass/fail in its output. Default poll interval 30s (min 5s, `--interval`).
 - To diagnose *why* a watched run failed, hand off to the `debug-pipeline` skill (`sem-ai diagnose <workflow-id>`).

--- a/assets/plugin/skills/watch-after-push/SKILL.md
+++ b/assets/plugin/skills/watch-after-push/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: watch-after-push
+description: After pushing commits to a Semaphore-backed repo, find the triggered CI run and watch it to completion, then report pass/fail. Use right after `git push`, or when the user asks "did my push pass", "watch CI", "is the build green", "what happened after I pushed", "watch the pipeline".
+user-invocable: false
+allowed-tools: Bash(sem-ai *), Bash(git *)
+---
+
+# Watch CI after a push
+
+When commits land on the remote of a Semaphore-managed repo (`.semaphore/` present), a pipeline is triggered. This skill finds that run for the exact commit you pushed and watches it to completion.
+
+> CI triggers on **push**, not on a local commit. A local commit alone starts nothing — push first.
+
+## Flow
+
+```bash
+# 0. Make sure the work is on the remote (CI fires on push, not commit).
+git push
+
+# 1. Pin the exact commit + branch you just pushed.
+SHA=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# 2. Find the workflow for THIS commit.
+#    A webhook -> pipeline lag of a few seconds is normal, so poll until it appears.
+#    Match on commit_sha (not just branch): collision-proof when several Semaphore
+#    projects share one repo URL, and it avoids grabbing a stale earlier run.
+WF=""
+for _ in 1 2 3 4 5 6; do
+  WF=$(sem-ai workflow list --branch "$BRANCH" 2>/dev/null \
+        | jq -r --arg sha "$SHA" '.[] | select(.commit_sha==$sha) | .id' \
+        | head -n1)
+  [ -n "$WF" ] && break
+  sleep 5
+done
+
+# 3. Watch to completion (polls every pipeline in the workflow until all are DONE).
+if [ -n "$WF" ]; then
+  sem-ai watch "$WF"
+else
+  echo "No workflow for $SHA yet — re-check 'sem-ai status' or the project mapping."
+fi
+```
+
+## Notes
+
+- `sem-ai workflow list` and `sem-ai status` auto-detect the project from the `origin` remote. Pass `--project <name>` only when detection is wrong.
+- **Repo-URL collisions:** if more than one Semaphore project points at the same git remote, detection returns the *first* match. The `commit_sha` filter above keeps you on the right run regardless; if `watch` still tracks the wrong project, pin it with `--project`.
+- `sem-ai watch` exits once every pipeline in the workflow reaches a terminal state, and reflects pass/fail in its output. Default poll interval 30s (min 5s, `--interval`).
+- To diagnose *why* a watched run failed, hand off to the `debug-pipeline` skill (`sem-ai diagnose <workflow-id>`).

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -314,7 +314,7 @@ func (s *deployTargetSpec) toBody(name string) (map[string]any, error) {
 }
 
 func bindDeploySpecFlags(cmd *cobra.Command, s *deployTargetSpec) {
-	cmd.Flags().StringVar(&s.projectFlag, "project", "", "project name or ID (required on create)")
+	cmd.Flags().StringVar(&s.projectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 	cmd.Flags().StringVar(&s.description, "description", "", "target description")
 	cmd.Flags().StringVar(&s.url, "url", "", "target URL")
 
@@ -439,7 +439,7 @@ var deployUpdateCmd = &cobra.Command{
 }
 
 func init() {
-	deployTargetsCmd.Flags().StringVar(&deployTargetsProjectFlag, "project", "", "project name or ID (required)")
+	deployTargetsCmd.Flags().StringVar(&deployTargetsProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 
 	bindDeploySpecFlags(deployCreateCmd, deployCreateSpec)
 

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -371,7 +371,7 @@ func init() {
 	pipelinePromoteCmd.Flags().BoolVar(&promoteOverrideFlag, "override", false, "override promotion conditions (e.g. promote despite failures)")
 	pipelinePromoteCmd.Flags().StringArrayVar(&promoteParamsFlag, "param", nil, "promotion parameters as key=value pairs")
 
-	pipelineListCmd.Flags().StringVar(&pipelineListProjectFlag, "project", "", "project name or ID (required)")
+	pipelineListCmd.Flags().StringVar(&pipelineListProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 	pipelineCmd.AddCommand(pipelineListCmd)
 	pipelineCmd.AddCommand(pipelineShowCmd)
 	pipelineCmd.AddCommand(pipelineStopCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,16 @@ func Execute() {
 	// Wrap all commands' Args validators to skip when --examples is set
 	patchArgsForExamples(rootCmd)
 
-	if err := rootCmd.Execute(); err != nil {
+	err := rootCmd.Execute()
+
+	// `status --exit-code` requests a poll-friendly process exit code. This is
+	// the only place os.Exit may run for it — the in-process MCP server calls
+	// rootCmd.Execute() directly (cmd/mcp.go) and never reaches here.
+	if statusExitCode != 0 {
+		os.Exit(statusExitCode)
+	}
+
+	if err != nil {
 		if err == errExamplesShown {
 			return
 		}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/semaphoreio/sem-ai/pkg/client"
 	"github.com/semaphoreio/sem-ai/pkg/config"
@@ -13,186 +14,305 @@ import (
 )
 
 var (
-	statusProjectFlag string
-	statusBranchFlag  string
+	statusProjectFlag  string
+	statusBranchFlag   string
+	statusPRFlag       string
+	statusExitCodeFlag bool
 )
+
+// Process exit codes for `status --exit-code`, so poll loops can branch on them.
+// 0 pass · 8 pending · 1 fail · 2 ambiguous (multi-project) · 3 no workflow / undetected.
+const (
+	exitPass       = 0
+	exitFail       = 1
+	exitAmbiguous  = 2
+	exitNoWorkflow = 3
+	exitPending    = 8
+)
+
+// statusExitCode is set by the status command when --exit-code is requested and
+// read by the CLI Execute() wrapper (cmd/root.go), which is the ONLY place that
+// may call os.Exit. The MCP server runs commands in-process via executeCobra,
+// which calls rootCmd.Execute() directly and never routes through Execute() —
+// so this never terminates the long-lived MCP process.
+var statusExitCode int
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Quick CI status for a branch or PR",
-	Long:  "Compound command: finds workflows for the current branch/PR, shows pipeline and job status summary.",
-	Example: `  sem-ai status
+	Short: "Quick CI status for the current branch, a PR, or a project",
+	Long: "Compound command: finds the CI workflow for the current commit/branch (or a PR), " +
+		"shows the pipeline and block status. Project and branch are auto-detected from the git " +
+		"remote and HEAD when not given. With --exit-code, returns a poll-friendly exit code.",
+	Example: `  sem-ai status                      # current repo, current branch, current commit
   sem-ai status --branch main
-  sem-ai status --project my-project --branch feature-x`,
+  sem-ai status --pr 422
+  sem-ai status --project my-project --branch feature-x
+  until sem-ai status --exit-code; do sleep 20; done   # watch to green`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		statusExitCode = 0
 		if !config.IsConfigured() {
 			return fmt.Errorf("not configured — run 'sem-ai connect' first")
 		}
 
-		// Resolve project
-		project := statusProjectFlag
-		if project == "" {
-			p, err := detectProject()
+		// Resolve candidate projects. An explicit --project pins exactly one;
+		// otherwise the git remote may match several Semaphore projects — we
+		// keep all of them and let the workflow lookup disambiguate.
+		var candidates []projectCandidate
+		if statusProjectFlag != "" {
+			id, err := resolveProjectID(statusProjectFlag)
 			if err != nil {
-				output.Error("context_error", "could not detect project from git remote — use --project", 1)
+				output.Error("project_error", err.Error(), 1)
 				return err
 			}
-			project = p
+			candidates = []projectCandidate{{Name: statusProjectFlag, ID: id}}
+		} else {
+			cands, err := detectProjectCandidates()
+			if err != nil {
+				if statusExitCodeFlag {
+					statusExitCode = exitNoWorkflow
+					return nil
+				}
+				output.Error("context_error", err.Error()+" — use --project", 1)
+				return err
+			}
+			candidates = cands
 		}
 
-		projectID, err := resolveProjectID(project)
-		if err != nil {
-			output.Error("project_error", err.Error(), 1)
-			return err
-		}
-
-		// Resolve branch
+		// Resolve the selector: a PR number (label) takes precedence over branch.
 		branch := statusBranchFlag
-		if branch == "" {
-			b, err := gitutil.CurrentBranch()
-			if err == nil {
+		if branch == "" && statusPRFlag == "" {
+			if b, err := gitutil.CurrentBranch(); err == nil {
 				branch = b
 			}
 		}
-
-		// Fetch workflows
-		params := url.Values{}
-		params.Set("project_id", projectID)
-		if branch != "" {
-			params.Set("branch_name", branch)
+		wantSHA := ""
+		if statusPRFlag == "" {
+			if sha, err := gitutil.CurrentCommitSHA(); err == nil {
+				wantSHA = sha
+			}
 		}
 
 		c := client.New()
-		resp, err := c.ListWithParams("plumber-workflows", params)
-		if err != nil {
-			output.Error("api_error", err.Error(), 1)
-			return err
-		}
-		if resp.StatusCode != 200 {
-			output.Error("api_error", fmt.Sprintf("HTTP %d", resp.StatusCode), resp.StatusCode)
-			return fmt.Errorf("API returned %d", resp.StatusCode)
-		}
-
-		var workflows []struct {
-			WfID         string `json:"wf_id"`
-			BranchName   string `json:"branch_name"`
-			CommitSHA    string `json:"commit_sha"`
-			InitialPplID string `json:"initial_ppl_id"`
-		}
-		if err := json.Unmarshal(resp.Body, &workflows); err != nil {
-			output.Error("parse_error", err.Error(), 1)
-			return err
+		var found []map[string]any
+		for _, cand := range candidates {
+			st, ok, err := fetchProjectStatus(c, cand, branch, statusPRFlag, wantSHA)
+			if err != nil {
+				output.Error("api_error", err.Error(), 1)
+				return err
+			}
+			if ok {
+				found = append(found, st)
+			}
 		}
 
-		if len(workflows) == 0 {
+		switch len(found) {
+		case 0:
+			selector := branch
+			if statusPRFlag != "" {
+				selector = "PR #" + statusPRFlag
+			}
+			if statusExitCodeFlag {
+				statusExitCode = exitNoWorkflow
+				return nil
+			}
 			output.Result(map[string]any{
-				"project": project,
-				"branch":  branch,
 				"status":  "no_workflows",
-				"message": "no workflows found for this branch",
+				"branch":  branch,
+				"message": fmt.Sprintf("no workflow found for %q in the detected project(s)", selector),
+			})
+			return nil
+		case 1:
+			st := found[0]
+			if statusExitCodeFlag {
+				statusExitCode = exitCodeForBucket(st["result_bucket"])
+			}
+			output.Result(st)
+			return nil
+		default:
+			// The repo maps to several Semaphore projects that each ran this
+			// commit/branch — never guess which one "is" the build.
+			if statusExitCodeFlag {
+				statusExitCode = exitAmbiguous
+			}
+			names := make([]string, len(found))
+			for i, st := range found {
+				names[i], _ = st["project"].(string)
+			}
+			output.Result(map[string]any{
+				"multiple_projects": true,
+				"message": fmt.Sprintf("this repo maps to %d Semaphore projects (%s) that ran this commit — pass --project to pick one",
+					len(found), strings.Join(names, ", ")),
+				"projects": found,
 			})
 			return nil
 		}
-
-		// Get latest workflow's pipeline (detailed=true to include blocks)
-		latest := workflows[0]
-		pplParams := url.Values{}
-		pplParams.Set("detailed", "true")
-		pplResp, err := c.ListWithParams("pipelines/"+latest.InitialPplID, pplParams)
-		if err != nil {
-			output.Error("api_error", err.Error(), 1)
-			return err
-		}
-
-		var pplData struct {
-			Pipeline struct {
-				PplID        string `json:"ppl_id"`
-				Name         string `json:"name"`
-				State        string `json:"state"`
-				Result       string `json:"result"`
-				ResultReason string `json:"result_reason"`
-				CreatedAt    string `json:"created_at"`
-				DoneAt       string `json:"done_at"`
-			} `json:"pipeline"`
-			Blocks []struct {
-				Name   string `json:"name"`
-				State  string `json:"state"`
-				Result string `json:"result"`
-				Jobs   []struct {
-					Name  string `json:"name"`
-					JobID string `json:"job_id"`
-				} `json:"jobs"`
-			} `json:"blocks"`
-		}
-
-		if pplResp.StatusCode == 200 {
-			_ = json.Unmarshal(pplResp.Body, &pplData)
-		}
-
-		// Build status summary
-		type blockStatus struct {
-			Name   string `json:"name"`
-			State  string `json:"state"`
-			Result string `json:"result,omitempty"`
-		}
-
-		blocks := make([]blockStatus, 0)
-		for _, b := range pplData.Blocks {
-			blocks = append(blocks, blockStatus{
-				Name:   b.Name,
-				State:  b.State,
-				Result: b.Result,
-			})
-		}
-
-		status := map[string]any{
-			"project":     project,
-			"branch":      latest.BranchName,
-			"commit_sha":  latest.CommitSHA,
-			"workflow_id":  latest.WfID,
-			"pipeline_id":  latest.InitialPplID,
-			"pipeline": map[string]any{
-				"name":          pplData.Pipeline.Name,
-				"state":         pplData.Pipeline.State,
-				"result":        pplData.Pipeline.Result,
-				"result_reason": pplData.Pipeline.ResultReason,
-				"created_at":    pplData.Pipeline.CreatedAt,
-				"done_at":       pplData.Pipeline.DoneAt,
-			},
-			"blocks":           blocks,
-			"total_workflows":  len(workflows),
-		}
-
-		output.Result(status)
-		return nil
 	},
 }
 
-// detectProject tries to find the Semaphore project name from git remote.
-func detectProject() (string, error) {
+// fetchProjectStatus looks up the workflow for the given selector in one project
+// and, if found, returns its pipeline status summary. ok=false means the project
+// has no matching workflow (so it is not part of the answer).
+func fetchProjectStatus(c *client.Client, proj projectCandidate, branch, pr, wantSHA string) (map[string]any, bool, error) {
+	params := url.Values{}
+	params.Set("project_id", proj.ID)
+	switch {
+	case pr != "":
+		params.Set("label", pr)
+	case branch != "":
+		params.Set("branch_name", branch)
+	}
+
+	resp, err := c.ListWithParams("plumber-workflows", params)
+	if err != nil {
+		return nil, false, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, false, fmt.Errorf("workflows: HTTP %d", resp.StatusCode)
+	}
+
+	var workflows []struct {
+		WfID         string `json:"wf_id"`
+		BranchName   string `json:"branch_name"`
+		CommitSHA    string `json:"commit_sha"`
+		InitialPplID string `json:"initial_ppl_id"`
+	}
+	if err := json.Unmarshal(resp.Body, &workflows); err != nil {
+		return nil, false, err
+	}
+	if len(workflows) == 0 {
+		return nil, false, nil
+	}
+
+	// Prefer the workflow for the exact HEAD commit; the API returns newest-first,
+	// so workflows[0] is the latest run on the branch as a fallback.
+	chosen := workflows[0]
+	matchedBy := "latest_on_branch"
+	if wantSHA != "" {
+		for _, w := range workflows {
+			if w.CommitSHA == wantSHA || strings.HasPrefix(w.CommitSHA, wantSHA) || strings.HasPrefix(wantSHA, w.CommitSHA) {
+				chosen = w
+				matchedBy = "commit_sha"
+				break
+			}
+		}
+	}
+
+	pplParams := url.Values{}
+	pplParams.Set("detailed", "true")
+	pplResp, err := c.ListWithParams("pipelines/"+chosen.InitialPplID, pplParams)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var pplData struct {
+		Pipeline struct {
+			Name         string `json:"name"`
+			State        string `json:"state"`
+			Result       string `json:"result"`
+			ResultReason string `json:"result_reason"`
+			CreatedAt    string `json:"created_at"`
+			DoneAt       string `json:"done_at"`
+		} `json:"pipeline"`
+		Blocks []struct {
+			Name   string `json:"name"`
+			State  string `json:"state"`
+			Result string `json:"result"`
+		} `json:"blocks"`
+	}
+	if pplResp.StatusCode == 200 {
+		_ = json.Unmarshal(pplResp.Body, &pplData)
+	}
+
+	type blockStatus struct {
+		Name   string `json:"name"`
+		State  string `json:"state"`
+		Result string `json:"result,omitempty"`
+	}
+	blocks := make([]blockStatus, 0, len(pplData.Blocks))
+	for _, b := range pplData.Blocks {
+		blocks = append(blocks, blockStatus{Name: b.Name, State: b.State, Result: b.Result})
+	}
+
+	st := map[string]any{
+		"project":         proj.Name,
+		"branch":          chosen.BranchName,
+		"commit_sha":      chosen.CommitSHA,
+		"matched_by":      matchedBy,
+		"workflow_id":     chosen.WfID,
+		"pipeline_id":     chosen.InitialPplID,
+		"total_workflows": len(workflows),
+		"pipeline": map[string]any{
+			"name":          pplData.Pipeline.Name,
+			"state":         pplData.Pipeline.State,
+			"result":        pplData.Pipeline.Result,
+			"result_reason": pplData.Pipeline.ResultReason,
+			"created_at":    pplData.Pipeline.CreatedAt,
+			"done_at":       pplData.Pipeline.DoneAt,
+		},
+		"result_bucket": bucketForPipeline(pplData.Pipeline.State, pplData.Pipeline.Result),
+	}
+	return st, true, nil
+}
+
+// bucketForPipeline collapses Semaphore's state/result into one of
+// passed / failed / pending, for both display and exit-code mapping.
+func bucketForPipeline(state, result string) string {
+	if state != "" && state != "done" {
+		return "pending"
+	}
+	if result == "passed" {
+		return "passed"
+	}
+	if result == "" {
+		return "pending"
+	}
+	return "failed"
+}
+
+func exitCodeForBucket(bucket any) int {
+	switch bucket {
+	case "passed":
+		return exitPass
+	case "pending":
+		return exitPending
+	default:
+		return exitFail
+	}
+}
+
+type projectCandidate struct {
+	Name string
+	ID   string
+}
+
+// detectProjectCandidates returns every Semaphore project whose repository
+// matches the current git remote ("origin"). It returns an empty slice when
+// nothing matches. Owner/repo is the stronger signal; a bare repo-name match is
+// only used when no owner/repo match exists.
+func detectProjectCandidates() ([]projectCandidate, error) {
 	remoteURL, err := gitutil.RemoteURL("origin")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
+	ownerRepo := gitutil.RepoOwnerAndName(remoteURL)
 	repoName := gitutil.RepoName(remoteURL)
-	if repoName == "" {
-		return "", fmt.Errorf("could not extract repo name from %q", remoteURL)
+	if ownerRepo == "" && repoName == "" {
+		return nil, fmt.Errorf("could not extract a repo name from remote %q", remoteURL)
 	}
 
-	// Try matching against Semaphore projects
 	c := client.New()
 	resp, err := c.List("projects")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return repoName, nil // fallback to repo name
+		return nil, fmt.Errorf("projects list returned HTTP %d", resp.StatusCode)
 	}
 
 	var projects []struct {
 		Metadata struct {
 			Name string `json:"name"`
+			ID   string `json:"id"`
 		} `json:"metadata"`
 		Spec struct {
 			Repository struct {
@@ -202,26 +322,50 @@ func detectProject() (string, error) {
 		} `json:"spec"`
 	}
 	if err := json.Unmarshal(resp.Body, &projects); err != nil {
-		return repoName, nil
+		return nil, err
 	}
 
-	// Match by repo URL or repo name
-	ownerRepo := gitutil.RepoOwnerAndName(remoteURL)
+	var byOwnerRepo, byName []projectCandidate
 	for _, p := range projects {
-		pOwnerRepo := gitutil.RepoOwnerAndName(p.Spec.Repository.URL)
-		if pOwnerRepo == ownerRepo {
-			return p.Metadata.Name, nil
-		}
-		if p.Spec.Repository.Name == repoName {
-			return p.Metadata.Name, nil
+		cand := projectCandidate{Name: p.Metadata.Name, ID: p.Metadata.ID}
+		if ownerRepo != "" && gitutil.RepoOwnerAndName(p.Spec.Repository.URL) == ownerRepo {
+			byOwnerRepo = append(byOwnerRepo, cand)
+		} else if repoName != "" && p.Spec.Repository.Name == repoName {
+			byName = append(byName, cand)
 		}
 	}
+	if len(byOwnerRepo) > 0 {
+		return byOwnerRepo, nil
+	}
+	return byName, nil
+}
 
-	return repoName, nil
+// detectProject returns the single Semaphore project for the current git remote.
+// It errors when the remote matches no project, or matches several (caller must
+// then pass --project) — it never guesses one of multiple matches.
+func detectProject() (string, error) {
+	cands, err := detectProjectCandidates()
+	if err != nil {
+		return "", err
+	}
+	switch len(cands) {
+	case 0:
+		return "", fmt.Errorf("could not detect a Semaphore project from git remote 'origin'")
+	case 1:
+		return cands[0].Name, nil
+	default:
+		names := make([]string, len(cands))
+		for i, c := range cands {
+			names[i] = c.Name
+		}
+		return "", fmt.Errorf("git remote 'origin' maps to %d Semaphore projects (%s)", len(cands), strings.Join(names, ", "))
+	}
 }
 
 func init() {
-	statusCmd.Flags().StringVar(&statusProjectFlag, "project", "", "project name (auto-detected from git remote if omitted)")
+	statusCmd.Flags().StringVar(&statusProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 	statusCmd.Flags().StringVar(&statusBranchFlag, "branch", "", "branch name (auto-detected from HEAD if omitted)")
+	statusCmd.Flags().StringVar(&statusPRFlag, "pr", "", "pull-request number (overrides --branch; matches the PR's workflow)")
+	statusCmd.Flags().BoolVar(&statusExitCodeFlag, "exit-code", false, "exit 0=pass 8=pending 1=fail 2=ambiguous 3=none (for poll loops)")
 	rootCmd.AddCommand(statusCmd)
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import "testing"
+
+func TestBucketForPipeline(t *testing.T) {
+	cases := []struct {
+		state, result, want string
+	}{
+		{"done", "passed", "passed"},
+		{"done", "failed", "failed"},
+		{"done", "stopped", "failed"},
+		{"done", "canceled", "failed"},
+		{"running", "", "pending"},
+		{"running", "passed", "pending"}, // not terminal yet → pending regardless of result
+		{"", "", "pending"},              // unknown/missing pipeline data
+		{"done", "", "pending"},          // terminal but no result yet
+	}
+	for _, c := range cases {
+		if got := bucketForPipeline(c.state, c.result); got != c.want {
+			t.Errorf("bucketForPipeline(%q,%q)=%q, want %q", c.state, c.result, got, c.want)
+		}
+	}
+}
+
+func TestExitCodeForBucket(t *testing.T) {
+	cases := []struct {
+		bucket any
+		want   int
+	}{
+		{"passed", exitPass},
+		{"pending", exitPending},
+		{"failed", exitFail},
+		{"", exitFail}, // unknown bucket is treated as a failure (never falsely green)
+		{nil, exitFail},
+	}
+	for _, c := range cases {
+		if got := exitCodeForBucket(c.bucket); got != c.want {
+			t.Errorf("exitCodeForBucket(%v)=%d, want %d", c.bucket, got, c.want)
+		}
+	}
+}

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -234,8 +234,8 @@ func yamlEscape(s string) string {
 }
 
 func init() {
-	taskListCmd.Flags().StringVar(&taskProjectFlag, "project", "", "project name or ID (required)")
-	taskCreateCmd.Flags().StringVar(&taskCreateProjectFlag, "project", "", "project name or ID (required)")
+	taskListCmd.Flags().StringVar(&taskProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
+	taskCreateCmd.Flags().StringVar(&taskCreateProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 	taskCreateCmd.Flags().StringVar(&taskCreateBranchFlag, "branch", "main", "branch to run on")
 	taskCreateCmd.Flags().StringVar(&taskCreateFileFlag, "file", ".semaphore/semaphore.yml", "pipeline YAML file")
 	taskCreateCmd.Flags().StringVar(&taskCreateCronFlag, "cron", "", "cron expression for recurring tasks")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -146,10 +146,6 @@ Returns each flaky test with its pass/fail ratio across recent runs.`,
 		if !config.IsConfigured() {
 			return fmt.Errorf("not configured — run 'sem-ai connect' first")
 		}
-		if testFlakyProjectFlag == "" {
-			return fmt.Errorf("--project is required")
-		}
-
 		projectID, err := resolveProjectID(testFlakyProjectFlag)
 		if err != nil {
 			output.Error("project_error", err.Error(), 1)
@@ -185,10 +181,7 @@ Returns each flaky test with its pass/fail ratio across recent runs.`,
 			return err
 		}
 
-		limit := testFlakyCountFlag
-		if limit > len(workflows) {
-			limit = len(workflows)
-		}
+		limit := min(testFlakyCountFlag, len(workflows))
 
 		// Track test outcomes across workflows
 		type testKey struct{ name, pkg string }
@@ -408,7 +401,7 @@ func decompressGzip(data []byte) ([]byte, error) {
 func init() {
 	testReportCmd.Flags().StringVar(&testPipelineFlag, "pipeline", "", "pipeline ID (required)")
 	testSummaryCmd.Flags().StringVar(&testSummaryPipelineFlag, "pipeline", "", "pipeline ID (required)")
-	testFlakyCmd.Flags().StringVar(&testFlakyProjectFlag, "project", "", "project name or ID (required)")
+	testFlakyCmd.Flags().StringVar(&testFlakyProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 	testFlakyCmd.Flags().StringVar(&testFlakyBranchFlag, "branch", "", "filter by branch")
 	testFlakyCmd.Flags().IntVar(&testFlakyCountFlag, "count", 5, "number of recent workflows to analyze")
 

--- a/cmd/workflow.go
+++ b/cmd/workflow.go
@@ -124,10 +124,18 @@ var workflowShowCmd = &cobra.Command{
 }
 
 // resolveProjectID converts a project name to its ID.
-// Tries direct GET first, falls back to listing all projects and matching by name.
+// When nameOrID is empty it auto-detects the project from the git remote
+// ("origin"); detectProject errors if the remote matches zero or several
+// projects, so callers no longer need to require --project explicitly.
+// Otherwise it tries a direct GET, then falls back to listing all projects
+// and matching by name.
 func resolveProjectID(nameOrID string) (string, error) {
 	if nameOrID == "" {
-		return "", fmt.Errorf("--project is required")
+		detected, err := detectProject()
+		if err != nil {
+			return "", fmt.Errorf("%w — pass --project", err)
+		}
+		nameOrID = detected
 	}
 
 	c := client.New()
@@ -175,7 +183,11 @@ func resolveProjectID(nameOrID string) (string, error) {
 // while query-param endpoints still want the ID.
 func resolveProject(nameOrID string) (name, id string, err error) {
 	if nameOrID == "" {
-		return "", "", fmt.Errorf("--project is required")
+		detected, derr := detectProject()
+		if derr != nil {
+			return "", "", fmt.Errorf("%w — pass --project", derr)
+		}
+		nameOrID = detected
 	}
 	c := client.New()
 
@@ -348,9 +360,9 @@ var workflowRunCmd = &cobra.Command{
 }
 
 func init() {
-	workflowListCmd.Flags().StringVar(&wfProjectFlag, "project", "", "project name or ID (required)")
+	workflowListCmd.Flags().StringVar(&wfProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 	workflowListCmd.Flags().StringVar(&wfBranchFlag, "branch", "", "filter by branch name")
-	workflowRunCmd.Flags().StringVar(&wfRunProjectFlag, "project", "", "project name or ID (required)")
+	workflowRunCmd.Flags().StringVar(&wfRunProjectFlag, "project", "", "project name or ID (auto-detected from git remote if omitted)")
 	workflowRunCmd.Flags().StringVar(&wfRunBranchFlag, "branch", "", "branch to run workflow on")
 	workflowCmd.AddCommand(workflowListCmd)
 	workflowCmd.AddCommand(workflowShowCmd)


### PR DESCRIPTION
## What

Make `sem-ai` answer "is the thing I'm working on green?" with **zero context** — no `--project`, no workflow id, no manual project↔repo mapping — so an agent (or human) in a checkout reaches for `sem-ai status` instead of `gh pr checks`. Plus the awareness hook and watch-after-push skill that started this PR.

### 1. `sem-ai status` — zero-context, SHA-precise, poll-friendly (binary)

- **Autodetect project + branch.** With no flags, `status` detects the project from the `origin` remote and the branch from `HEAD`.
- **Pins the current commit.** Among the branch's workflows it picks the one whose `commit_sha` matches `HEAD` (`matched_by: "commit_sha"`), falling back to the latest run on the branch (`latest_on_branch`).
- **`--pr N`** resolves a pull-request's workflow directly (via the `label` filter), no branch/commit needed.
- **`--exit-code`** (opt-in) returns a poll-friendly code — `0` pass · `8` pending · `1` fail · `2` ambiguous · `3` none — so `until sem-ai status --exit-code; do sleep 20; done` watches to green and ports existing `gh pr checks` loops verbatim.
- **Multi-project repos: never guess.** When the remote maps to several Semaphore projects, `status` returns all of them (`multiple_projects: true`) and `--exit-code` is `2`; pass `--project` to pick one.

### 2. `--project` is now optional everywhere (binary)

`resolveProjectID("")` / `resolveProject("")` fall back to git-remote autodetection, so `workflow list/run`, `pipeline list`, `deploy targets/create`, `task list/create`, and `test flaky` no longer require `--project` inside a checkout. `detectProject()` resolves through `detectProjectCandidates()`, which returns **all** matching projects and errors (rather than guessing) on zero or several — keeping the "don't assume" guarantee for the multi-project case.

The `--exit-code` process exit is set via a package var read only in the CLI `Execute()` wrapper; the in-process MCP server calls `rootCmd.Execute()` directly and never reaches it, so `status` stays exit-0 / JSON for MCP callers (no long-running, mutex-holding tool added to the MCP surface).

### 3. Semaphore-awareness SessionStart hook (plugin)

`hooks/detect-semaphore.sh`: in a `.semaphore/` repo it tells the agent to drive CI through `sem-ai` (not GitHub Actions) **and** runs `sem-ai status` to inject the current branch's live CI state (project, branch, pipeline state/result, workflow id) — surfacing the multiple-projects / no-run cases instead of guessing. The lookup is bounded by a `perl`-alarm timeout and is fully best-effort: it degrades to static guidance if `sem-ai` is unconfigured, slow, or absent. Silent (exit 0) for non-Semaphore repos.

### 4. Skills (plugin)

- **`watch-after-push`** (new): after a push, find the run for the exact `commit_sha` and `sem-ai watch` it to completion. SHA-matching is collision-proof when several projects share one remote.
- **`semaphore-ci`** (router): CI-status row → flagless `sem-ai status`; new "did my push pass?" row; one line preferring `sem-ai status` over `gh pr checks` for the green check (it reads the same Semaphore status and keeps the failure drill `sem-ai diagnose` one tool away; `gh` is an acceptable fallback); project-detection prose updated for optional `--project` everywhere + `multiple_projects`.
- **`project-health`**: HEAD-commit pinning + `--exit-code` note.
- **`testbox` / `debug-pipeline` / `init` / `gha-to-semaphore`**: drop mandatory `--project`; hand the post-push watch off to `watch-after-push` (commit_sha-pinned) instead of branch-only one-shots; fix `workflow_list`/`job_log` → `workflow list`/`job log`.
- **`semaphore-blocks`**: lead with `sem-ai watch` / `status --exit-code` for the is-it-green case; keep the result-not-state loop as the rationale.

### Docs

`README`: cross-agent `npx skills add semaphoreio/sem-ai` install path (skills only — no hooks/MCP, binary still required), and `watch-after-push` listed in the bundle.

## Testing

- `go build`, `go vet`, `golangci-lint` (govet/ineffassign/unused), and `go test ./cmd/...` (new `status_test.go` covers the state→bucket→exit-code mapping).
- Live verification against real workflows: flagless `status` SHA-pins the current commit; `--pr 1056` resolves a PR's run; `--exit-code` returns 0/8/3 correctly; flagless `workflow list` autodetects; and in an org where the repo isn't a project, `status` honestly returns `no_workflows` (exit 3) rather than guessing.
- JSON lint (`hooks.json`), `bash -n`, and a behavior check of the hook (emits live status in a Semaphore repo, silent elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
