### PR TITLE
chore(release): bump plugin manifests to v0.1.20

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.19"
+      "version": "0.1.20"
     }
   ]
 }

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {


### PR DESCRIPTION
Bumps the plugin manifests to **v0.1.20**, releasing the zero-context `status` work merged in #48 (autodetect `--project` across repo-scoped commands, SHA-pinned `status`, `--pr N`, poll-friendly `--exit-code`, multi-project safety, the SessionStart awareness hook, and the refreshed skills bundle).

- `.claude-plugin/marketplace.json` → `plugins[0].version: 0.1.20`
- `assets/plugin/plugin.json` → `version: 0.1.20`

The annotated tag `v0.1.20` is already pushed (it points at this branch's commit `45d7fe9` = `main` + this bump), so the release/marketplace is published. This PR just lands the same bump on `main` so the branch manifests match the released tag — `main` is protected, so the bump has to come through review (`release.sh`'s direct push was rejected).

Prefer a **merge commit** (not squash) so the tagged commit lands on `main`'s history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)