### PR TITLE
chore(release): bump plugin manifests to v0.1.21

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.19"
+      "version": "0.1.21"
     }
   ]
 }

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {


### PR DESCRIPTION
Bumps plugin + marketplace manifests to **v0.1.21**.

Supersedes #49 (v0.1.20 manifest bump) — going straight to 0.1.21 so the release includes the flaky-tests + insights commands that landed after the v0.1.20 tag.

Included since v0.1.20:
- #47 — `sem-ai flaky` (list/show/disruptions/trends) + `sem-ai insights` (performance/reliability/frequency), CLI + MCP

Tag `v0.1.21` will point at this bump commit (release pipeline gates on manifest==tag via `make check-versions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)