### PR TITLE
fix(testparse): capture passed tests so flaky detection works

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -45,6 +45,21 @@ Returns structured test data: pass/fail counts, individual failures with file/li
 			return err
 		}
 
+		// The parser captures every test (needed for flaky detection across
+		// runs); `test report` focuses on failures, so trim passes here.
+		for _, r := range reports {
+			if r.Report == nil {
+				continue
+			}
+			failures := r.Report.Tests[:0]
+			for _, t := range r.Report.Tests {
+				if t.Status != "passed" {
+					failures = append(failures, t)
+				}
+			}
+			r.Report.Tests = failures
+		}
+
 		output.Result(reports)
 		return nil
 	},

--- a/pkg/testparse/parse.go
+++ b/pkg/testparse/parse.go
@@ -342,18 +342,19 @@ func parseSemaphoreTestResults(data []byte) *TestReport {
 
 		for _, suite := range tr.Suites {
 			for _, t := range suite.Tests {
-				if t.State != "passed" {
-					tr := TestResult{
-						Name:    t.Name,
-						Package: suite.Name,
-						Status:  t.State,
-						File:    t.File,
-					}
-					if t.Failure != nil {
-						tr.Message = t.Failure.Message
-					}
-					report.Tests = append(report.Tests, tr)
+				// Capture every test with its state (passed/failed/skipped),
+				// not just failures — flaky detection needs to see a test
+				// both pass and fail across runs to flag it.
+				res := TestResult{
+					Name:    t.Name,
+					Package: suite.Name,
+					Status:  t.State,
+					File:    t.File,
 				}
+				if t.Failure != nil {
+					res.Message = t.Failure.Message
+				}
+				report.Tests = append(report.Tests, res)
 			}
 		}
 	}

--- a/pkg/testparse/parse_test.go
+++ b/pkg/testparse/parse_test.go
@@ -651,15 +651,51 @@ func TestParseJUnitJSONSemaphoreFormat(t *testing.T) {
 		t.Errorf("Skipped = %d, want 1", got.Skipped)
 	}
 
-	// Should only include non-passed tests
+	// Every test is captured with its state (passed and failed alike) —
+	// flaky detection needs to see a test both pass and fail across runs.
+	if len(got.Tests) != 2 {
+		t.Fatalf("expected 2 test details (passed + failed), got %d", len(got.Tests))
+	}
+	byName := map[string]TestResult{}
+	for _, tr := range got.Tests {
+		byName[tr.Name] = tr
+	}
+	if byName["TestA"].Status != "passed" {
+		t.Errorf("TestA status = %q, want passed", byName["TestA"].Status)
+	}
+	if byName["TestB"].Status != "failed" {
+		t.Errorf("TestB status = %q, want failed", byName["TestB"].Status)
+	}
+	if byName["TestB"].Message != "expected 1, got 2" {
+		t.Errorf("TestB message = %q", byName["TestB"].Message)
+	}
+}
+
+// Regression: the Semaphore test-results parser must report a test's passed
+// state, not just its failures. Dropping passes broke `test flaky`, which
+// flags a test only when it sees it both pass and fail across runs.
+func TestParseJUnitJSONCapturesPassedTests(t *testing.T) {
+	data := []byte(`{
+		"testResults": [{
+			"name": "unit",
+			"framework": "go",
+			"summary": {"total": 1, "passed": 1, "failed": 0, "skipped": 0, "error": 0},
+			"suites": [{
+				"name": "MySuite",
+				"tests": [{"name": "TestFlaky", "state": "passed"}]
+			}]
+		}]
+	}`)
+
+	got := ParseJUnitJSON(data)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
 	if len(got.Tests) != 1 {
-		t.Fatalf("expected 1 failed test detail, got %d", len(got.Tests))
+		t.Fatalf("expected the passed test to be captured, got %d tests", len(got.Tests))
 	}
-	if got.Tests[0].Name != "TestB" {
-		t.Errorf("Test name = %q, want TestB", got.Tests[0].Name)
-	}
-	if got.Tests[0].Message != "expected 1, got 2" {
-		t.Errorf("Test message = %q", got.Tests[0].Message)
+	if got.Tests[0].Name != "TestFlaky" || got.Tests[0].Status != "passed" {
+		t.Errorf("got %q/%q, want TestFlaky/passed", got.Tests[0].Name, got.Tests[0].Status)
 	}
 }
 


### PR DESCRIPTION
## Problem

`sem-ai test flaky` always returned `flaky_count: 0`, even for tests with a clear pass/fail history across runs.

Root cause is in the Semaphore test-results JSON parser (`pkg/testparse.parseSemaphoreTestResults`): it only appended test cases whose state was **not** `"passed"`:

```go
if t.State != "passed" {
    report.Tests = append(report.Tests, ...)
}
```

`test flaky` builds its per-test pass/fail history from `report.Tests`. Because passed runs were dropped, a flaky test only ever showed up as `["failed", "failed", ...]` — never both passed and failed — so the `passes > 0 && fails > 0` check never fired.

## Fix

- **`pkg/testparse/parse.go`** — capture every test with its state (passed/failed/skipped), not just failures. (Also drops a confusing variable shadow.)
- **`cmd/test.go`** — `test report` trims passed tests at the presentation layer, so its failures-focused output is unchanged. `test summary` already filters to failures, so it's unaffected.
- **`pkg/testparse/parse_test.go`** — update the Semaphore-format test (it asserted the buggy "failures only" behavior) and add a regression test that a passed test is captured.

## Verification

Seeded a real flaky test on a Semaphore project (12 runs, mixed pass/fail). Before: `flaky_count: 0`. After:

```json
{
  "flaky_count": 1,
  "flaky_tests": [
    { "name": "TestConcurrentRouteCache", "package": "github.com/gorilla/mux",
      "pass_count": 9, "fail_count": 2, "appearances": 11, "flaky_rate": "18%" }
  ]
}
```

`go test ./...`, `go vet ./...` pass.

## Tracking

renderedtext/project-tasks#3413
