### PR TITLE
chore(release): bump plugin manifests to v0.1.22

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.21"
+      "version": "0.1.22"
     }
   ]
 }

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {


### PR DESCRIPTION
Release **v0.1.22**. Bumps `.claude-plugin/marketplace.json` + `assets/plugin/plugin.json` to 0.1.22.

Includes since v0.1.21:
- #44 — client identification headers (`x-client-*` + W3C `traceparent`) for API attribution
- #51 — testparse: capture passed tests so flaky detection works

After merge: tag `v0.1.22` on the merged commit and push it → the `Publish GitHub Release` pipeline (GoReleaser) builds and publishes. The release CI gate verifies the manifests match the tag.