### PR TITLE
fix(testbox): fail fast when debug sessions are disabled

### DIFF
--- a/cmd/testbox.go
+++ b/cmd/testbox.go
@@ -22,9 +22,9 @@ machine type, secrets, and cache — then syncs your local code and executes com
 }
 
 var (
-	testboxWarmupProjectFlag     string
-	testboxWarmupMachineFlag     string
-	testboxWarmupOSImageFlag     string
+	testboxWarmupProjectFlag  string
+	testboxWarmupMachineFlag  string
+	testboxWarmupOSImageFlag  string
 	testboxWarmupDurationFlag time.Duration
 )
 
@@ -95,6 +95,12 @@ var testboxWarmupCmd = &cobra.Command{
 
 		jobID := job.Metadata.ID
 
+		if probe, perr := c.Get("jobs", jobID+"/debug_ssh_key"); perr == nil && probe.StatusCode == 403 {
+			c.PostAction("jobs", jobID, "stop", nil)
+			output.Error("testbox_error", debugDisabledMsg(project, probe.Body), 1)
+			return fmt.Errorf("debug sessions disabled for project %q", project)
+		}
+
 		// Poll until RUNNING
 		fmt.Fprintf(os.Stderr, "Warming up testbox for %s ", project)
 		for i := 0; i < 120; i++ {
@@ -126,18 +132,37 @@ var testboxWarmupCmd = &cobra.Command{
 			return fmt.Errorf("warmup timeout")
 		}
 
-		// Get SSH key
 		sshResp, err := c.Get("jobs", jobID+"/debug_ssh_key")
 		if err != nil {
+			c.PostAction("jobs", jobID, "stop", nil)
 			output.Error("api_error", err.Error(), 1)
 			return err
+		}
+		if sshResp.StatusCode != 200 {
+			c.PostAction("jobs", jobID, "stop", nil)
+			if sshResp.StatusCode == 403 {
+				output.Error("testbox_error", debugDisabledMsg(project, sshResp.Body), 1)
+			} else {
+				output.Error("testbox_error", fmt.Sprintf("could not get SSH debug key (HTTP %d): %s", sshResp.StatusCode, string(sshResp.Body)), 1)
+			}
+			return fmt.Errorf("SSH key unavailable")
 		}
 
 		var sshKey struct {
 			Key string `json:"key"`
 		}
-		if sshResp.StatusCode == 200 {
-			json.Unmarshal(sshResp.Body, &sshKey)
+		json.Unmarshal(sshResp.Body, &sshKey)
+		if sshKey.Key == "" {
+			c.PostAction("jobs", jobID, "stop", nil)
+			output.Error("testbox_error", "SSH debug key was empty — debug sessions may be disabled for this project", 1)
+			return fmt.Errorf("empty SSH key")
+		}
+
+		keyFile := fmt.Sprintf("/tmp/.sem-testbox-%s.key", jobID)
+		if err := os.WriteFile(keyFile, []byte(sshKey.Key), 0600); err != nil {
+			c.PostAction("jobs", jobID, "stop", nil)
+			output.Error("testbox_error", fmt.Sprintf("could not write SSH key file: %s", err), 1)
+			return err
 		}
 
 		sshPort := findSSHPort(job)
@@ -153,18 +178,13 @@ var testboxWarmupCmd = &cobra.Command{
 				"port": sshPort,
 				"user": "semaphore",
 			},
-			"expires_in": testboxWarmupDurationFlag.String(),
+			"expires_in":   testboxWarmupDurationFlag.String(),
+			"ssh_key_file": keyFile,
 			"usage": map[string]string{
 				"run":  fmt.Sprintf("sem-ai testbox run --id %s \"your-command\"", jobID),
 				"ssh":  fmt.Sprintf("sem-ai testbox ssh --id %s", jobID),
 				"stop": fmt.Sprintf("sem-ai testbox stop --id %s", jobID),
 			},
-		}
-
-		if sshKey.Key != "" {
-			keyFile := fmt.Sprintf("/tmp/.sem-testbox-%s.key", jobID)
-			os.WriteFile(keyFile, []byte(sshKey.Key), 0600)
-			result["ssh_key_file"] = keyFile
 		}
 
 		output.Result(result)
@@ -186,6 +206,18 @@ type jobStatus struct {
 			} `json:"ports"`
 		} `json:"agent"`
 	} `json:"status"`
+}
+
+func debugDisabledMsg(project string, body []byte) string {
+	msg := fmt.Sprintf(
+		"debug/SSH sessions are disabled for project %q — testbox needs them.\n"+
+			"Enable \"Collaborators can start empty debug sessions\" under the project's "+
+			"Settings → Permissions, or ask an organization admin to enable it.",
+		project)
+	if len(body) > 0 {
+		msg += fmt.Sprintf("\nServer response: %s", string(body))
+	}
+	return msg
 }
 
 func findSSHPort(job jobStatus) int {

--- a/cmd/testbox_test.go
+++ b/cmd/testbox_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDebugDisabledMsg(t *testing.T) {
+	msg := debugDisabledMsg("my-app", nil)
+
+	if !strings.Contains(msg, "my-app") {
+		t.Errorf("message should name the project, got: %q", msg)
+	}
+	if !strings.Contains(msg, "Collaborators can start empty debug sessions") {
+		t.Errorf("message should point at the exact setting to enable, got: %q", msg)
+	}
+	if strings.Contains(msg, "Server response") {
+		t.Errorf("message should omit the server-response line when body is empty, got: %q", msg)
+	}
+}
+
+func TestDebugDisabledMsgWithBody(t *testing.T) {
+	body := []byte(`{"code":7,"message":"You are not allowed to debug this project"}`)
+	msg := debugDisabledMsg("my-app", body)
+
+	if !strings.Contains(msg, "Server response") {
+		t.Errorf("message should include the server response when body is present, got: %q", msg)
+	}
+	if !strings.Contains(msg, "not allowed to debug this project") {
+		t.Errorf("message should surface the raw server body, got: %q", msg)
+	}
+}


### PR DESCRIPTION
## Problem

`sem-ai testbox warmup` creates a real CI VM via Semaphore's debug-session API, then fetches the SSH key with `GET /api/v1alpha/jobs/:id/debug_ssh_key`. A testbox job has no branch/PR/hook, so the server treats it as an **empty** debug session.

When an organization is restricted and the project doesn't allow empty debug sessions — i.e. the **"Collaborators can start empty debug sessions"** checkbox under *Project Settings → Permissions* is off — the API returns **HTTP 403** from `debug_ssh_key`. (Branch/PR/tag debug checkboxes don't help here; only the empty-sessions one does.)

The old code only read the key on HTTP 200 and **silently ignored any non-200**:

```go
if sshResp.StatusCode == 200 {
    json.Unmarshal(sshResp.Body, &sshKey)
}
```

So warmup still printed `status:"ready"` (without `ssh_key_file`), left the VM running, and every later `testbox run` / `testbox ssh` failed with `Permission denied (publickey)` and no clue why. Job creation isn't gated — only the key fetch is — so it *looked* like everything worked.

## Fix

Branch on the `debug_ssh_key` status code:

| Status | Meaning | Behavior |
|---|---|---|
| 200 + non-empty key | allowed, VM up | proceed, write key file |
| 403 | blocked (no empty-session permission) | fatal, actionable message, stop the VM |
| 400 (`failed_precondition`) | allowed but VM not running yet | keep polling (not an error) |
| other non-200 / empty key | unknown / transient | fatal, stop the VM |

The permission check runs before the "is the VM running" check on the server, so a 403 comes back immediately after job creation. We **probe the key right after creating the job** and bail before a VM is ever allocated when debug is disabled. The post-running fetch is now also fatal on non-200/empty, and any failure path stops the VM so we don't leak a running machine.

The error message names the exact setting to flip:

```
debug/SSH sessions are disabled for project "my-app" — testbox needs them.
Enable "Collaborators can start empty debug sessions" under the project's
Settings → Permissions, or ask an organization admin to enable it.
```

## Testing

- `go build ./...`, `go vet ./cmd/...`, `gofmt` clean
- `go test ./...` green; added `cmd/testbox_test.go` covering the error-message helper (with and without a server body)
