### PR TITLE
chore(release): v0.1.23

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.22"
+      "version": "0.1.23"
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DATE      := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS   := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 INSTALL   := /usr/local/bin
 
-.PHONY: build install uninstall clean test fmt vet release check-versions
+.PHONY: build install uninstall clean test fmt vet release tag check-versions
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -30,16 +30,23 @@ fmt:
 vet:
 	go vet ./...
 
-# Check plugin manifests are consistent.
-#   make check-versions            # both files match each other
-#   make check-versions TAG=0.1.8  # both also match the given tag
+# Check plugin manifests are consistent (all three carry the same version).
+#   make check-versions            # files match each other
+#   make check-versions TAG=0.1.8  # files also match the given tag
 check-versions:
 	@./scripts/check-manifest-versions.sh $(TAG)
 
-# Bump plugin manifests, commit, and tag a new release.
+# PR-based release, step 1: bump plugin manifests + commit on a release branch.
 #   make release VERSION=0.1.8              # apply
 #   make release VERSION=0.1.8 DRY_RUN=1    # preview, no changes
-# Thin wrapper around scripts/release.sh. Does NOT push — review
-# locally, then run the printed git push commands.
+# Open a PR with the commit and squash-merge it, then run `make tag`.
 release:
 	@./scripts/release.sh $(if $(DRY_RUN),--dry-run,) "$(VERSION)"
+
+# PR-based release, step 2: tag the merged bump on main (run after `make release`
+# merges and you `git checkout main && git pull`). Prints the tag-push command
+# that triggers the GoReleaser publish pipeline.
+#   make tag VERSION=0.1.8
+#   make tag VERSION=0.1.8 DRY_RUN=1
+tag:
+	@./scripts/tag-release.sh $(if $(DRY_RUN),--dry-run,) "$(VERSION)"

--- a/assets/plugin/.codex-plugin/plugin.json
+++ b/assets/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.18",
+  "version": "0.1.23",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "repository": "https://github.com/semaphoreio/sem-ai",

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {

--- a/scripts/check-manifest-versions.sh
+++ b/scripts/check-manifest-versions.sh
@@ -2,9 +2,14 @@
 # Check that plugin manifest versions are consistent.
 #
 # Usage:
-#   scripts/check-manifest-versions.sh                  # both files match each other
-#   scripts/check-manifest-versions.sh v0.1.8           # both match the given tag
+#   scripts/check-manifest-versions.sh                  # all manifests match each other
+#   scripts/check-manifest-versions.sh v0.1.8           # all match the given tag
 #   scripts/check-manifest-versions.sh 0.1.8            # leading 'v' optional
+#
+# Covers every file that carries the plugin version:
+#   .claude-plugin/marketplace.json        (.plugins[0].version)
+#   assets/plugin/plugin.json              (.version)
+#   assets/plugin/.codex-plugin/plugin.json (.version)
 #
 # Exits non-zero on any mismatch with a clear diagnostic.
 
@@ -12,11 +17,14 @@ set -euo pipefail
 
 MARKETPLACE=".claude-plugin/marketplace.json"
 PLUGIN="assets/plugin/plugin.json"
+CODEX="assets/plugin/.codex-plugin/plugin.json"
 
-if [[ ! -f "$MARKETPLACE" || ! -f "$PLUGIN" ]]; then
-  echo "ERROR: run from repo root — missing $MARKETPLACE or $PLUGIN" >&2
-  exit 2
-fi
+for f in "$MARKETPLACE" "$PLUGIN" "$CODEX"; do
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: run from repo root — missing $f" >&2
+    exit 2
+  fi
+done
 
 if ! command -v yq >/dev/null 2>&1; then
   echo "ERROR: yq required" >&2
@@ -25,12 +33,14 @@ fi
 
 market_ver=$(yq -p json -o tsv '.plugins[0].version' "$MARKETPLACE")
 plugin_ver=$(yq -p json -o tsv '.version' "$PLUGIN")
+codex_ver=$(yq -p json -o tsv '.version' "$CODEX")
 
-if [[ "$market_ver" != "$plugin_ver" ]]; then
+if [[ "$market_ver" != "$plugin_ver" || "$market_ver" != "$codex_ver" ]]; then
   echo "FAIL: plugin manifest versions disagree" >&2
   echo "  $MARKETPLACE  → $market_ver" >&2
   echo "  $PLUGIN       → $plugin_ver" >&2
-  echo "  bump both with: make release VERSION=<X.Y.Z>" >&2
+  echo "  $CODEX        → $codex_ver" >&2
+  echo "  bump all with: make release VERSION=<X.Y.Z>" >&2
   exit 1
 fi
 
@@ -40,7 +50,7 @@ if [[ $# -ge 1 ]]; then
     echo "FAIL: manifest version does not match expected tag" >&2
     echo "  manifests advertise: $market_ver" >&2
     echo "  expected (from tag): $expected" >&2
-    echo "  bump both with: make release VERSION=$expected" >&2
+    echo "  bump all with: make release VERSION=$expected" >&2
     exit 1
   fi
   echo "OK: manifests at $market_ver (matches tag v$expected)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
-# Bump plugin manifests, commit, and tag a new release.
+# Bump plugin manifests and commit, on a release branch, for the PR-based flow.
 #
 # Usage:
-#   scripts/release.sh 0.1.8
-#   scripts/release.sh v0.1.8                # leading 'v' allowed
-#   scripts/release.sh --dry-run 0.1.8       # validate + print actions, no changes
+#   scripts/release.sh 0.1.8                  # bump + commit on the current branch
+#   scripts/release.sh v0.1.8                 # leading 'v' allowed
+#   scripts/release.sh --dry-run 0.1.8        # validate + print actions, no changes
 #
-# Does NOT push — prints the push commands instead so release stays
-# gated on a deliberate human action.
+# `main` is protected (PR required, linear history), so a release can no longer
+# be pushed straight to main. This script does ONE half of the flow: bump the
+# manifests and commit them on a feature branch. The other half — tagging the
+# squashed bump commit once the PR merges — is scripts/tag-release.sh.
+#
+# Full flow:
+#   1. git checkout -b mk/sem-ai/release-vX.Y.Z origin/main
+#   2. scripts/release.sh X.Y.Z          # this script: bump + commit
+#   3. git push -u origin HEAD && gh pr create ...   # open PR, squash-merge
+#   4. git checkout main && git pull
+#   5. scripts/tag-release.sh X.Y.Z      # tag the merged bump + print push cmd
+#
+# Bumps every file that carries the plugin version:
+#   .claude-plugin/marketplace.json        (.plugins[0].version)
+#   assets/plugin/plugin.json              (.version)
+#   assets/plugin/.codex-plugin/plugin.json (.version)
+#
+# Does NOT push and does NOT tag — release stays gated on deliberate human steps.
 
 set -euo pipefail
 
 MARKETPLACE=".claude-plugin/marketplace.json"
 PLUGIN="assets/plugin/plugin.json"
+CODEX="assets/plugin/.codex-plugin/plugin.json"
 
 dry_run=0
 if [[ "${1:-}" == "--dry-run" ]]; then
@@ -46,10 +63,12 @@ if ! command -v yq >/dev/null 2>&1; then
   exit 2
 fi
 
-if [[ ! -f "$MARKETPLACE" || ! -f "$PLUGIN" ]]; then
-  echo "ERROR: run from repo root — missing $MARKETPLACE or $PLUGIN" >&2
-  exit 2
-fi
+for f in "$MARKETPLACE" "$PLUGIN" "$CODEX"; do
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: run from repo root — missing $f" >&2
+    exit 2
+  fi
+done
 
 if [[ "$dry_run" -eq 0 ]]; then
   if [[ -n "$(git status --porcelain)" ]]; then
@@ -58,8 +77,9 @@ if [[ "$dry_run" -eq 0 ]]; then
   fi
 
   branch="$(git rev-parse --abbrev-ref HEAD)"
-  if [[ "$branch" != "main" ]]; then
-    echo "ERROR: must run on main branch (currently on $branch)" >&2
+  if [[ "$branch" == "main" ]]; then
+    echo "ERROR: main is protected — bump on a release branch, not main" >&2
+    echo "  git checkout -b mk/sem-ai/release-v$version origin/main" >&2
     exit 1
   fi
 fi
@@ -71,19 +91,22 @@ fi
 
 run yq -i -o json ".plugins[0].version = \"$version\"" "$MARKETPLACE"
 run yq -i -o json ".version = \"$version\"" "$PLUGIN"
+run yq -i -o json ".version = \"$version\"" "$CODEX"
 
 if [[ "$dry_run" -eq 0 ]]; then
-  git --no-pager diff --stat "$MARKETPLACE" "$PLUGIN"
+  git --no-pager diff --stat "$MARKETPLACE" "$PLUGIN" "$CODEX"
 fi
-run git add "$MARKETPLACE" "$PLUGIN"
+run git add "$MARKETPLACE" "$PLUGIN" "$CODEX"
 run git commit -m "chore(release): bump plugin manifests to v$version"
-run git tag -a "v$version" -m "v$version"
 
 echo
 if [[ "$dry_run" -eq 1 ]]; then
-  echo "DRY-RUN: no files changed, no commit, no tag."
+  echo "DRY-RUN: no files changed, no commit."
   echo "Re-run without --dry-run to apply."
 else
-  echo "Bumped + committed + tagged v$version locally. To publish:"
-  echo "  git push origin main && git push origin v$version"
+  echo "Bumped + committed v$version on branch $(git rev-parse --abbrev-ref HEAD). Next:"
+  echo "  git push -u origin HEAD && gh pr create --fill"
+  echo "  # after the PR squash-merges:"
+  echo "  git checkout main && git pull"
+  echo "  scripts/tag-release.sh $version"
 fi

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tag a merged release bump and print the push command that publishes it.
+#
+# Second half of the PR-based release flow (first half: scripts/release.sh).
+# Run on main AFTER the manifest-bump PR has squash-merged.
+#
+# Usage:
+#   scripts/tag-release.sh 0.1.8             # tag v0.1.8 on the current main HEAD
+#   scripts/tag-release.sh v0.1.8            # leading 'v' allowed
+#   scripts/tag-release.sh --dry-run 0.1.8   # validate + print actions, no changes
+#
+# Verifies HEAD's manifests advertise the version (so the tag can't land on the
+# wrong commit), creates an annotated tag, and prints the push. Pushing the tag
+# triggers .semaphore/release.yml (check-versions → goreleaser publish).
+#
+# Does NOT push — the tag push is the deliberate, irreversible publish step.
+
+set -euo pipefail
+
+dry_run=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=1
+  shift
+fi
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  echo "ERROR: version required" >&2
+  echo "Usage: scripts/tag-release.sh [--dry-run] <X.Y.Z>" >&2
+  exit 2
+fi
+
+version="${1#v}"
+
+run() {
+  if [[ "$dry_run" -eq 1 ]]; then
+    echo "DRY-RUN: $*"
+  else
+    "$@"
+  fi
+}
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "ERROR: version must match X.Y.Z (got '$version')" >&2
+  exit 2
+fi
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$branch" != "main" ]]; then
+  echo "ERROR: tag the release on main (currently on $branch)" >&2
+  echo "  git checkout main && git pull" >&2
+  exit 1
+fi
+
+if [[ -n "$(git tag -l "v$version")" ]]; then
+  echo "ERROR: tag v$version already exists locally" >&2
+  exit 1
+fi
+
+# HEAD must actually carry this version, or the tag would publish the wrong commit.
+if ! scripts/check-manifest-versions.sh "$version"; then
+  echo "ERROR: HEAD manifests do not match v$version — is the bump PR merged + pulled?" >&2
+  exit 1
+fi
+
+run git tag -a "v$version" -m "v$version"
+
+echo
+if [[ "$dry_run" -eq 1 ]]; then
+  echo "DRY-RUN: no tag created."
+  echo "Re-run without --dry-run to apply."
+else
+  echo "Tagged v$version on $(git rev-parse --short HEAD). To publish:"
+  echo "  git push origin v$version"
+fi


### PR DESCRIPTION
## What

Cuts **v0.1.23**, releasing the two changes merged on top of v0.1.22:
- #55 — fix-flaky skill + `flaky list` compaction + `flaky failure` command
- #54 — testbox: fail fast when debug sessions are disabled

It also repairs the release tooling for the protected-`main` reality.

## Version bump

Bumps all three files that carry the plugin version to `0.1.23`:

| file | was | now |
|---|---|---|
| `.claude-plugin/marketplace.json` | 0.1.22 | 0.1.23 |
| `assets/plugin/plugin.json` | 0.1.22 | 0.1.23 |
| `assets/plugin/.codex-plugin/plugin.json` | **0.1.18** | 0.1.23 |

The Codex manifest had silently drifted **4 releases behind** — the old tooling only knew about the marketplace + plugin manifests, so it was never bumped and `check-versions` never noticed.

## Tooling fix (PR-based release flow)

`main` is now protected (PR required, linear history, signatures), so a release can no longer be pushed straight to main as the old `release.sh` assumed. Split into two gated halves:

- `scripts/release.sh` — bump all manifests + commit on a release branch (now **refuses** to run on `main`).
- `scripts/tag-release.sh` *(new)* — run on `main` after the bump PR squash-merges: verifies HEAD advertises the version, creates the annotated tag, prints the tag-push that triggers the GoReleaser pipeline.
- `scripts/check-manifest-versions.sh` + both `make` targets now cover the Codex manifest, so this drift can't recur.

## Release steps after this merges

```
git checkout main && git pull
make tag VERSION=0.1.23      # tags v0.1.23, prints the push
git push origin v0.1.23      # triggers .semaphore/release.yml → GoReleaser publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)