### PR TITLE
chore(release): human-readable release notes (github-native changelog)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-autolabel.yml
+++ b/.github/workflows/pr-autolabel.yml
@@ -1,0 +1,31 @@
+name: PR autolabel
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title || "";
+            const m = title.match(/^(\w+)(\(([^)]*)\))?!?:/);
+            if (!m) return;
+            const type = m[1];
+            const scope = m[3] || "";
+            const map = { feat: "enhancement", fix: "bug", docs: "documentation" };
+            let label = map[type];
+            if (type === "chore" && scope === "release") label = "skip-changelog";
+            if (!label) return;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: [label],
+            });

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,10 +38,4 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - "^docs:"
-      - "^test:"
-      - "^chore:"
-      - "^ci:"
+  use: github-native

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,7 +33,7 @@ blocks:
 
         - name: Lint
           commands:
-            - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin"
+            - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
             - "$(go env GOPATH)/bin/golangci-lint run ./..."
 
         - name: Tests
@@ -50,7 +50,7 @@ blocks:
           commands:
             - go test -coverprofile=coverage.out ./...
             - go tool cover -func=coverage.out
-            - artifact push workflow coverage.out
+            - artifact push workflow coverage.out --force
 
   - name: Security
     dependencies: []


### PR DESCRIPTION
## What

Release notes were a raw SHA dump (`<full-sha> <subject>`), and the `^chore:`-style GoReleaser filters missed *scoped* conventional commits — so the `chore(release):` bump PR leaked into the v0.1.23 notes.

This makes release notes human-readable and keeps them that way with zero per-PR effort.

### `.goreleaser.yaml` — github-native notes
`changelog.use: github-native`. Notes become the familiar **"What's Changed"** list of **PR titles + author handles + a Full Changelog compare link**, generated by GitHub.

### `.github/release.yml` — grouping & exclusion
Drives the notes (used both by GoReleaser and the `generate-notes` API). Groups by **PR label**:
- `enhancement` → 🚀 Features
- `bug` → 🐛 Bug Fixes
- `documentation` → 📚 Documentation
- `*` → Other Changes
- excludes `skip-changelog` + bot authors (release-bump PRs vanish).

### `.github/workflows/pr-autolabel.yml` — keep it zero-touch
Tiny GitHub Action that labels each PR from its conventional-commit title (`feat`→`enhancement`, `fix`→`bug`, `docs`→`documentation`, `chore(release)`→`skip-changelog`). **Labels only — no CI, doesn't touch Semaphore.** The title is read via the `github-script` `context` object (runtime value, not `${{ }}`-interpolated into a shell) and the label comes from a fixed map, so the untrusted title is never executed.

## Follow-up (after merge, no code)

Backfill the notes for the last 3 releases (v0.1.21–v0.1.23) via the `generate-notes` API — it reads `.github/release.yml` from the default branch, which is why this PR lands first. Historical PRs in that range get labelled per the same mapping so the backfilled notes group correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also (rode along — was blocking this PR's own CI)

Two pre-existing CI flakes surfaced while getting this PR green, fixed in the last commit:
- **Lint**: `golangci-lint` install hit GitHub's *latest-release* API and 504'd → pinned `v2.12.2` to skip that lookup.
- **Coverage**: `artifact push ... coverage.out` lacked `--force`, so any workflow rerun failed (artifact already exists) → added `--force`.

These block reruns/releases generally, not just this PR.
