### PR TITLE
docs(fix-flaky): de-overfit diagnosis playbook to generic classes

### DIFF
--- a/assets/plugin/skills/fix-flaky/SKILL.md
+++ b/assets/plugin/skills/fix-flaky/SKILL.md
@@ -45,17 +45,21 @@ If that returns matches in several apps, disambiguate with the `test_group`/suit
 from `flaky show` (e.g. a group like `MyApp.Web.WidgetTest` → the `web` app).
 Read the test AND the code it exercises — flakes live in the seam.
 
-### 4. Diagnose — match the playbook
-First **pull the real failure** when you can (see *Pull the actual failure* below):
-the `left:`/`right:` + stacktrace beat guessing. Then match the playbook:
-| signal | likely class | typical fix |
+### 4. Classify from the real failure — the table names the class, it does NOT hand you the fix
+**Pull the real failure first** (see *Pull the actual failure* below): the
+`left:`/`right:` + stacktrace are the diagnosis. The table only names the
+**class** of nondeterminism and the **direction** a fix usually takes, so you
+know what you're chasing — the actual fix comes from the test in front of you,
+never from a cell.
+
+| signal | likely class | fix direction |
 |---|---|---|
-| asserts `==:lt`/`>` on consecutive `now()`/timestamps; ~95% pass | clock-tie / nondeterministic time | inclusive comparison on BOTH bounds (`in [:lt,:eq]` / `[:gt,:eq]`), or freeze/inject time |
-| UI test clicks an element a poller/JS re-renders; `StaleReferenceError` | stale-element after async render | wrap the click in a retry-on-stale helper (a presence-assert does NOT fix it — the node goes stale *after* lookup) |
-| in-test wait/sleep budget < failure tail | timeout too short for async work | raise the wait budget to match a non-flaky sibling; make the predicate nil-safe |
-| asserts order of a list query with no `ORDER BY` | nondeterministic DB/collection order | add deterministic ordering at the source |
-| depends on leftover state between tests | shared/global state | isolate setup/teardown; unique fixtures |
-| asserts a count of OTP processes/children (e.g. `count_children` → `%{active: N, workers: N}`) that's off by one+ | leaked process from a prior test (shared named supervisor / registered GenServer) | terminate/drain the named processes in `setup`/`on_exit`, not just the DB |
+| asserts strict `<`/`>` (or `compare == :lt`/`:gt`) on two timestamps taken close together; passes most runs | clock-tie / nondeterministic time | allow the tie (inclusive bound), or freeze/inject time so the values are deterministic |
+| element acted on after an async re-render; `StaleReferenceError` | stale-element after async render | retry the lookup+action on stale — a presence-assert does NOT fix it (the node goes stale *after* lookup) |
+| in-test wait/sleep budget shorter than the work's failure tail | timeout too short for async work | raise the wait budget to match a non-flaky sibling; make the predicate nil-safe |
+| asserts order of a query/collection with no explicit ordering | nondeterministic ordering | add deterministic ordering at the source |
+| passes alone but fails after other tests (leftover rows/keys/processes) | shared/global state | isolate setup/teardown; unique fixtures |
+| asserts a count of live processes/children that's off by one+ | leaked process from a prior test (shared named supervisor / registered process) | terminate/drain the named process in `setup`/`on_exit`, not just the DB |
 | calls a real external service | external dependency | stub/mock, or mark + isolate |
 
 p95 (from `flaky show`) is the heuristic **only for the timeout row** — for


### PR DESCRIPTION
## Why

The step-4 diagnosis table in the `fix-flaky` skill had cells reverse-engineered from a few specific tests (e.g. `count_children → %{active: N, workers: N}`, `compare == :lt` → fix `in [:lt, :eq]`). On those exact tests it's a perfect match; on any other repo the cells read as answer-keys, and a clean run tends to parrot the canned fix instead of diagnosing the test in front of it.

## What

- Reframe step 4: pull the real `flaky failure` first — the table now names the **class** of nondeterminism and the **fix direction** only, never the fix itself.
- Genericize the table cells (drop test-specific shapes and language-specific naming).

Net: diagnosis is driven by the real failure evidence, so the skill still nails the cases it used to without going canned on unfamiliar repos.

## Validation

Ran the skill from a clean Claude instance (only sem-ai installed) against the hardest case — the exact test one of the old answer-key cells was mined from. It led with `flaky failure`, diagnosed from the actual code (a shared named supervisor with transient restart-loop workers leaking across tests), and wrote a one-place `setup` drain using the manager's real `children/0` + `finish_schedule_task/1`. No parroting, and it never needed a worked-example crutch.

No version bump (bundled at release).