### PR TITLE
docs: list fix-flaky skill + fix discover skills tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ codex plugin marketplace add semaphoreio/sem-ai
 codex plugin add sem-ai@semaphoreio
 ```
 
-The plugin drops every sem-ai skill (debug-pipeline, deploy, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox, watch-after-push) into your host.
+The plugin drops every sem-ai skill (debug-pipeline, deploy, fix-flaky, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox, watch-after-push) into your host.
 
 Claude Code refreshes registered marketplaces at session start, picks up the new plugin version, and applies it automatically — there is no manifest flag to set for this. To force an immediate refresh:
 

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -19,7 +19,7 @@ var discoverCmd = &cobra.Command{
 			"tips": map[string]string{
 				"setup":       "Run 'sem-ai connect <host> <token>' to authenticate",
 				"examples":    "Run 'sem-ai <command> --examples' for usage examples on any command",
-				"skills":      "Run 'sem-ai install-skills' to install AI agent skill definitions",
+				"skills":      "Install the Claude Code / Codex plugin ('/plugin marketplace add semaphoreio/sem-ai' then '/plugin install sem-ai@semaphoreio'), or 'npx skills add semaphoreio/sem-ai --all' for other agents",
 				"debug":       "For CI failures, start with 'sem-ai diagnose <workflow-id>'",
 				"format":      "All commands output JSON. Use --format table for human display",
 			},


### PR DESCRIPTION
Two small doc/UX fixes surfaced while auditing sem-ai docs drift:

- **README bundled-skills list** was missing `fix-flaky` (it ships in `assets/plugin/skills/fix-flaky/`).
- **`discover` skills tip** told agents to run `sem-ai install-skills` — a command that does not exist. The string only ever lived as this tip; running it errors with "unknown command". Repointed to the real install paths: the Claude Code / Codex plugin and the cross-agent `npx skills` installer.

`go build ./...` clean. No tests assert the old tip string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)