### PR TITLE
fix(skills): valid YAML frontmatter for sem-ai-bootstrap (Codex skip)

### DIFF
--- a/assets/plugin/skills/sem-ai-bootstrap/SKILL.md
+++ b/assets/plugin/skills/sem-ai-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sem-ai-bootstrap
-description: Diagnose sem-ai plugin issues when the sem-ai binary isn't installed yet, and guide the user through binary install. Use when the user reports sem-ai not working, MCP tools missing, slash command not found, `sem-ai connect` failing, or sees "command not found: sem-ai".
+description: 'Diagnose sem-ai plugin issues when the sem-ai binary isn''t installed yet, and guide the user through binary install. Use when the user reports sem-ai not working, MCP tools missing, slash command not found, `sem-ai connect` failing, or sees "command not found: sem-ai".'
 ---
 
 # sem-ai bootstrap


### PR DESCRIPTION
Closes #43.

Codex skipped loading the `sem-ai-bootstrap` skill with:

> invalid YAML: mapping values are not allowed in this context at line 2 column 273

**Cause:** the `description` value contains `command not found: sem-ai`. The unquoted `: ` (colon-space) is parsed as a `key: value` mapping by strict YAML parsers, so Codex rejects the frontmatter. Claude Code's looser parser accepted it, which hid the bug.

**Fix:** single-quote the description (with the lone apostrophe in `isn't` doubled per YAML rules). The rendered string is byte-for-byte unchanged.

Verified with `yq`: the fixed file parses, the description round-trips exactly, and all 17 bundled `SKILL.md` frontmatters are now valid YAML (the other 16 already were — they have no colon-space in the value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)