### PR TITLE
chore(release): v0.1.24

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.1.23"
+      "version": "0.1.24"
     }
   ]
 }

--- a/assets/plugin/.codex-plugin/plugin.json
+++ b/assets/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "repository": "https://github.com/semaphoreio/sem-ai",

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {


### PR DESCRIPTION
Bumps the plugin manifests (marketplace, Claude Code, Codex) to **v0.1.24**.

Per the PR-based release flow: squash-merge this, then on `main` run `scripts/tag-release.sh 0.1.24` to tag the bump and trigger the GoReleaser publish.

## Changes since v0.1.23
- **Fix:** `sem-ai-bootstrap` SKILL.md frontmatter is now valid YAML so Codex stops skipping it (#60, closes #43).
- **Docs:** README bundled-skills list adds `fix-flaky`; `discover` skills tip no longer advertises the non-existent `sem-ai install-skills` (#59).
- **Docs:** de-overfit the fix-flaky diagnosis playbook to generic failure classes (#58).
- **Chore:** human-readable release notes / GitHub-native changelog (#57).

No binary/CLI behavior changes — manifest + skills/docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)