### PR TITLE
feat(task): parameters on task run, param definitions on create

### DIFF
--- a/assets/plugin/skills/deploy/SKILL.md
+++ b/assets/plugin/skills/deploy/SKILL.md
@@ -27,8 +27,9 @@ sem-ai promote-and-wait <id> --target "Staging Deploy" --confirm
 # Override conditions (deploy despite failures)
 sem-ai pipeline promote <id> --target "Staging" --confirm --override
 
-# With parameters
+# With parameters (each --param becomes a promotion env var)
 sem-ai pipeline promote <id> --target "Production" --confirm --param version=1.2.3
+sem-ai pipeline promote <id> --target "Production Deploy" --confirm --param SERVICE=web
 ```
 
 ## Deployment targets — read

--- a/assets/plugin/skills/manage-infra/SKILL.md
+++ b/assets/plugin/skills/manage-infra/SKILL.md
@@ -36,6 +36,12 @@ sem-ai task list --project <p>
 sem-ai task show <id>
 sem-ai task run <id>                # trigger now
 sem-ai task delete <id>
+
+# Parameterized tasks: pass parameters, branch, and pipeline file.
+# Parameters go to the task's run_now as a map; branch/pipeline-file pick
+# the ref + YAML the task pipeline runs.
+sem-ai task run <id> --param KEY=VALUE [--param ...] \
+  [--branch <ref>] [--pipeline-file <path>]
 ```
 
 ## Artifacts

--- a/assets/plugin/skills/manage-infra/SKILL.md
+++ b/assets/plugin/skills/manage-infra/SKILL.md
@@ -33,7 +33,7 @@ sem-ai agent delete <type-name>     # delete type
 ## Scheduled tasks
 ```bash
 sem-ai task list --project <p>
-sem-ai task show <id>
+sem-ai task show <id>               # details + recent triggers
 sem-ai task run <id>                # trigger now
 sem-ai task delete <id>
 
@@ -42,6 +42,11 @@ sem-ai task delete <id>
 # the ref + YAML the task pipeline runs.
 sem-ai task run <id> --param KEY=VALUE [--param ...] \
   [--branch <ref>] [--pipeline-file <path>]
+
+# Create with parameter definitions: bare NAME = required,
+# NAME=DEFAULT = optional with a default value.
+sem-ai task create <name> --branch main --file <path> [--cron "<expr>"] \
+  [--param-def NAME] [--param-def NAME=DEFAULT]
 ```
 
 ## Artifacts

--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/semaphoreio/sem-ai/pkg/client"
 	"github.com/semaphoreio/sem-ai/pkg/config"
@@ -320,22 +321,14 @@ Safety:
 			"override":    promoteOverrideFlag,
 		}
 
-		// Parse --param key=val pairs
-		if len(promoteParamsFlag) > 0 {
-			envVars := make([]map[string]string, 0, len(promoteParamsFlag))
-			for _, p := range promoteParamsFlag {
-				for i := range p {
-					if p[i] == '=' {
-						envVars = append(envVars, map[string]string{
-							"name":  p[:i],
-							"value": p[i+1:],
-						})
-						break
-					}
-				}
-			}
-			if len(envVars) > 0 {
-				reqBody["parameters"] = envVars
+		// Promotion parameters go as top-level body keys: the v1alpha
+		// /promotions endpoint maps every key except
+		// pipeline_id/name/override/request_token/switch_id/user_id to a
+		// promotion env var. A nested "parameters" array makes the server
+		// encode a list as an env-var string value and 500.
+		for _, p := range promoteParamsFlag {
+			if k, v, ok := strings.Cut(p, "="); ok {
+				reqBody[k] = v
 			}
 		}
 

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -165,17 +165,19 @@ var taskDeleteCmd = &cobra.Command{
 }
 
 var (
-	taskCreateProjectFlag string
-	taskCreateBranchFlag  string
-	taskCreateFileFlag    string
-	taskCreateCronFlag    string
+	taskCreateProjectFlag  string
+	taskCreateBranchFlag   string
+	taskCreateFileFlag     string
+	taskCreateCronFlag     string
+	taskCreateParamDefFlag []string
 )
 
 var taskCreateCmd = &cobra.Command{
-	Use:     "create <name>",
-	Short:   "Create a scheduled task (periodic job)",
-	Args:    cobra.ExactArgs(1),
-	Example: `  sem-ai task create nightly-tests --project my-app --branch main --file .semaphore/nightly.yml --cron "0 2 * * *"`,
+	Use:   "create <name>",
+	Short: "Create a scheduled task (periodic job)",
+	Args:  cobra.ExactArgs(1),
+	Example: `  sem-ai task create nightly-tests --project my-app --branch main --file .semaphore/nightly.yml --cron "0 2 * * *"
+  sem-ai task create deploy-env --branch main --file .semaphore/deploy.yml --param-def ENVIRONMENT=staging --param-def VERSION`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.IsConfigured() {
 			return fmt.Errorf("not configured — run 'sem-ai connect' first")
@@ -212,7 +214,12 @@ var taskCreateCmd = &cobra.Command{
 			}
 		}
 
-		yml := buildScheduleYAML(args[0], projectName, taskCreateBranchFlag, taskCreateFileFlag, taskCreateCronFlag)
+		paramDefs, err := parseParamDefs(taskCreateParamDefFlag)
+		if err != nil {
+			return err
+		}
+
+		yml := buildScheduleYAML(args[0], projectName, taskCreateBranchFlag, taskCreateFileFlag, taskCreateCronFlag, paramDefs)
 		bodyBytes, _ := json.Marshal(map[string]string{"yml_definition": yml})
 
 		resp, err := c.Post("tasks", bodyBytes)
@@ -234,10 +241,37 @@ var taskCreateCmd = &cobra.Command{
 	},
 }
 
+// taskParamDef is a parameter definition on a task (not a run-time value).
+type taskParamDef struct {
+	Name         string
+	Required     bool
+	DefaultValue string
+}
+
+// parseParamDefs turns repeatable --param-def flags into definitions.
+// Bare NAME declares a required parameter; NAME=DEFAULT declares an
+// optional one with a default value.
+func parseParamDefs(defs []string) ([]taskParamDef, error) {
+	out := make([]taskParamDef, 0, len(defs))
+	for _, d := range defs {
+		i := strings.IndexByte(d, '=')
+		switch {
+		case i == 0 || d == "":
+			return nil, fmt.Errorf("invalid --param-def %q: expected NAME or NAME=DEFAULT", d)
+		case i < 0:
+			out = append(out, taskParamDef{Name: d, Required: true})
+		default:
+			out = append(out, taskParamDef{Name: d[:i], Required: false, DefaultValue: d[i+1:]})
+		}
+	}
+	return out, nil
+}
+
 // buildScheduleYAML renders the apiVersion/kind/metadata/spec doc that
 // v1alpha POST /tasks (apply schedule) expects as yml_definition.
-// apiVersion v1.1 enables one-off tasks via recurring:false (no `at`).
-func buildScheduleYAML(name, project, branch, pipelineFile, cron string) string {
+// apiVersion v1.1 enables one-off tasks via recurring:false (no `at`)
+// and parameter definitions.
+func buildScheduleYAML(name, project, branch, pipelineFile, cron string, params []taskParamDef) string {
 	recurring := cron != ""
 	var b strings.Builder
 	b.WriteString("apiVersion: v1.1\n")
@@ -251,6 +285,16 @@ func buildScheduleYAML(name, project, branch, pipelineFile, cron string) string 
 	fmt.Fprintf(&b, "  recurring: %t\n", recurring)
 	if recurring {
 		fmt.Fprintf(&b, "  at: %q\n", cron)
+	}
+	if len(params) > 0 {
+		b.WriteString("  parameters:\n")
+		for _, p := range params {
+			fmt.Fprintf(&b, "    - name: %s\n", yamlEscape(p.Name))
+			fmt.Fprintf(&b, "      required: %t\n", p.Required)
+			if !p.Required {
+				fmt.Fprintf(&b, "      default_value: %s\n", yamlEscape(p.DefaultValue))
+			}
+		}
 	}
 	return b.String()
 }
@@ -273,6 +317,7 @@ func init() {
 	taskCreateCmd.Flags().StringVar(&taskCreateBranchFlag, "branch", "main", "branch to run on")
 	taskCreateCmd.Flags().StringVar(&taskCreateFileFlag, "file", ".semaphore/semaphore.yml", "pipeline YAML file")
 	taskCreateCmd.Flags().StringVar(&taskCreateCronFlag, "cron", "", "cron expression for recurring tasks")
+	taskCreateCmd.Flags().StringArrayVar(&taskCreateParamDefFlag, "param-def", nil, "parameter definition as NAME (required) or NAME=DEFAULT (optional with default); repeatable")
 
 	taskRunCmd.Flags().StringArrayVar(&taskRunParamsFlag, "param", nil, "task parameter as KEY=VALUE (repeatable)")
 	taskRunCmd.Flags().StringVar(&taskRunBranchFlag, "branch", "", "git ref the task pipeline runs on (e.g. master); defaults to the task's configured branch")

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -20,8 +20,8 @@ var taskCmd = &cobra.Command{
 var taskProjectFlag string
 
 var taskListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List scheduled tasks for a project",
+	Use:     "list",
+	Short:   "List scheduled tasks for a project",
 	Example: `  sem-ai task list --project my-project`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.IsConfigured() {
@@ -77,17 +77,51 @@ var taskShowCmd = &cobra.Command{
 	},
 }
 
+var (
+	taskRunParamsFlag []string
+	taskRunBranchFlag string
+	taskRunFileFlag   string
+)
+
 var taskRunCmd = &cobra.Command{
-	Use:     "run <id>",
-	Short:   "Trigger a scheduled task to run now",
-	Args:    cobra.ExactArgs(1),
-	Example: `  sem-ai task run <task-id>`,
+	Use:   "run <id>",
+	Short: "Trigger a scheduled task to run now",
+	Args:  cobra.ExactArgs(1),
+	Example: `  sem-ai task run <task-id>
+  sem-ai task run <task-id> --param KEY=VALUE --param KEY2=VALUE2
+  sem-ai task run <task-id> --branch main --pipeline-file .semaphore/pipeline.yml --param KEY=VALUE`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.IsConfigured() {
 			return fmt.Errorf("not configured — run 'sem-ai connect' first")
 		}
+
+		// Build a run_now body only when overrides are supplied; otherwise
+		// send nil to preserve the parameter-less default behaviour.
+		var body []byte
+		if len(taskRunParamsFlag) > 0 || taskRunBranchFlag != "" || taskRunFileFlag != "" {
+			reqBody := map[string]any{}
+			if taskRunBranchFlag != "" {
+				reqBody["branch"] = taskRunBranchFlag
+			}
+			if taskRunFileFlag != "" {
+				reqBody["pipeline_file"] = taskRunFileFlag
+			}
+			params := map[string]string{}
+			for _, p := range taskRunParamsFlag {
+				i := strings.IndexByte(p, '=')
+				if i <= 0 {
+					return fmt.Errorf("invalid --param %q: expected KEY=VALUE", p)
+				}
+				params[p[:i]] = p[i+1:]
+			}
+			if len(params) > 0 {
+				reqBody["parameters"] = params
+			}
+			body, _ = json.Marshal(reqBody)
+		}
+
 		c := client.New()
-		resp, err := c.PostAction("tasks", args[0], "run_now", nil)
+		resp, err := c.PostAction("tasks", args[0], "run_now", body)
 		if err != nil {
 			output.Error("api_error", err.Error(), 1)
 			return err
@@ -138,9 +172,9 @@ var (
 )
 
 var taskCreateCmd = &cobra.Command{
-	Use:   "create <name>",
-	Short: "Create a scheduled task (periodic job)",
-	Args:  cobra.ExactArgs(1),
+	Use:     "create <name>",
+	Short:   "Create a scheduled task (periodic job)",
+	Args:    cobra.ExactArgs(1),
 	Example: `  sem-ai task create nightly-tests --project my-app --branch main --file .semaphore/nightly.yml --cron "0 2 * * *"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.IsConfigured() {
@@ -239,6 +273,10 @@ func init() {
 	taskCreateCmd.Flags().StringVar(&taskCreateBranchFlag, "branch", "main", "branch to run on")
 	taskCreateCmd.Flags().StringVar(&taskCreateFileFlag, "file", ".semaphore/semaphore.yml", "pipeline YAML file")
 	taskCreateCmd.Flags().StringVar(&taskCreateCronFlag, "cron", "", "cron expression for recurring tasks")
+
+	taskRunCmd.Flags().StringArrayVar(&taskRunParamsFlag, "param", nil, "task parameter as KEY=VALUE (repeatable)")
+	taskRunCmd.Flags().StringVar(&taskRunBranchFlag, "branch", "", "git ref the task pipeline runs on (e.g. master); defaults to the task's configured branch")
+	taskRunCmd.Flags().StringVar(&taskRunFileFlag, "pipeline-file", "", "pipeline YAML file the task runs; defaults to the task's configured file")
 
 	taskCmd.AddCommand(taskListCmd)
 	taskCmd.AddCommand(taskShowCmd)

--- a/cmd/task_test.go
+++ b/cmd/task_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseParamDefs(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want []taskParamDef
+		err  bool
+	}{
+		{nil, []taskParamDef{}, false},
+		{[]string{"VERSION"}, []taskParamDef{{Name: "VERSION", Required: true}}, false},
+		{[]string{"ENVIRONMENT=staging"}, []taskParamDef{{Name: "ENVIRONMENT", Required: false, DefaultValue: "staging"}}, false},
+		{[]string{"EMPTY_DEFAULT="}, []taskParamDef{{Name: "EMPTY_DEFAULT", Required: false, DefaultValue: ""}}, false},
+		{[]string{"WITH_EQ=a=b"}, []taskParamDef{{Name: "WITH_EQ", Required: false, DefaultValue: "a=b"}}, false},
+		{[]string{"A", "B=x"}, []taskParamDef{{Name: "A", Required: true}, {Name: "B", Required: false, DefaultValue: "x"}}, false},
+		{[]string{"=oops"}, nil, true},
+		{[]string{""}, nil, true},
+	}
+	for _, tc := range cases {
+		got, err := parseParamDefs(tc.in)
+		if tc.err {
+			if err == nil {
+				t.Errorf("%v: want error, got %v", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%v: unexpected error: %v", tc.in, err)
+			continue
+		}
+		if len(got) != len(tc.want) {
+			t.Errorf("%v: got %d defs, want %d", tc.in, len(got), len(tc.want))
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("%v[%d]: got %+v, want %+v", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestBuildScheduleYAMLWithParams(t *testing.T) {
+	yml := buildScheduleYAML("nightly", "my-app", "main", ".semaphore/nightly.yml", "0 2 * * *", []taskParamDef{
+		{Name: "VERSION", Required: true},
+		{Name: "ENVIRONMENT", Required: false, DefaultValue: "staging"},
+	})
+	for _, want := range []string{
+		"apiVersion: v1.1\n",
+		"kind: Periodic\n",
+		"  recurring: true\n",
+		"  at: \"0 2 * * *\"\n",
+		"  parameters:\n",
+		"    - name: VERSION\n      required: true\n",
+		"    - name: ENVIRONMENT\n      required: false\n      default_value: staging\n",
+	} {
+		if !strings.Contains(yml, want) {
+			t.Errorf("YAML missing %q:\n%s", want, yml)
+		}
+	}
+}
+
+func TestBuildScheduleYAMLNoParams(t *testing.T) {
+	yml := buildScheduleYAML("oneoff", "my-app", "main", ".semaphore/run.yml", "", nil)
+	if strings.Contains(yml, "parameters:") {
+		t.Errorf("unexpected parameters block:\n%s", yml)
+	}
+	if !strings.Contains(yml, "recurring: false") {
+		t.Errorf("expected recurring: false:\n%s", yml)
+	}
+}


### PR DESCRIPTION
## Summary

Make sem-ai's parameterized API calls work — v1alpha only. Changes:

1. **`task run`** — support parameters at all (they were silently dropped).
2. **`pipeline promote`** — fix `--param`, which sent the wrong body shape and returned HTTP 500.
3. **`task create --param-def`** — define parameters when creating a task (new).

> **Scope note:** `task activate/deactivate` and `task update` were originally part of this PR but depend on the v2 API, which we can't ship against yet. They're parked on the [`skipi/task-v2-mutations`](https://github.com/semaphoreio/sem-ai/tree/skipi/task-v2-mutations) branch and will come back as a separate PR once v2 is available.

## 1. `task run`: support `--param`, `--branch`, `--pipeline-file`

`sem-ai task run <id>` posted `run_now` with a **nil body**, so task parameters were silently dropped — parameterized scheduled tasks couldn't be triggered from the CLI at all.

Adds to `task run`:
- `--param KEY=VALUE` (repeatable)
- `--branch` — git ref the task pipeline runs on
- `--pipeline-file` — pipeline YAML the task runs

The body is built **only when an override is supplied**, so the parameter-less default is unchanged.

Shape: `run_now` consumes `parameters` as a **map**, with `branch` / `pipeline_file` alongside.

## 2. `pipeline promote`: fix `--param` (was HTTP 500)

`pipeline promote --param` sent parameters nested as `"parameters": [{name, value}]`. But the `POST /promotions` endpoint maps **every non-reserved top-level body key** — everything except `switch_id`/`name`/`user_id`/`override`/`request_token`/`pipeline_id` — to a promotion env var whose `value` must be a **string**. The nested array left `parameters` as a list-valued env var, so the server rejected it (`EnvVariable` value invalid) and returned **HTTP 500**.

Fix: send each `--param` as a flat top-level body key.

> **Why the two paths differ:** `run_now` consumes `parameters` as a **map**; `/promotions` consumes flat **top-level keys**. Intentional per-endpoint contract — each is now correct.

## 3. `task create --param-def`

`--param-def NAME` defines a required parameter; `--param-def NAME=DEFAULT` an optional one with a default. Emitted as the `parameters:` block in the v1.1 schedule YAML. Without this, `task run --param` was only usable against UI-created tasks.

## Verified

- `task run` with `--param` / `--branch` / `--pipeline-file` → triggers a parameterized task: `200 { "workflow_id": "…" }`.
- `pipeline promote <id> --target "<promotion>" --param KEY=VALUE --confirm` → `200`, promotion triggered.
- Live smoke on a scratch task (created → verified → deleted): `create --param-def VERSION --param-def ENVIRONMENT=staging` lands both definitions (required/optional+default).
- Unit tests for `parseParamDefs` + schedule-YAML rendering; `go vet` + `go test ./...` pass; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
