### PR TITLE
fix(cli): surface cobra parse errors instead of failing silently

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,6 +104,9 @@ func Execute() {
 		if err == errExamplesShown {
 			return
 		}
+		if !output.Reported() {
+			fmt.Fprintln(os.Stderr, "Error:", err)
+		}
 		os.Exit(1)
 	}
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -16,6 +16,12 @@ var (
 	format = "json"
 	stdout io.Writer = os.Stdout
 	stderr io.Writer = os.Stderr
+
+	// reported tracks whether Error has already written to stderr this
+	// invocation. The Execute wrapper in cmd/root.go checks this to avoid
+	// double-printing: cobra parse errors never call Error, so reported stays
+	// false for them and Execute can safely print the raw error itself.
+	reported bool
 )
 
 func SetFormat(f string) {
@@ -32,6 +38,7 @@ func GetFormat() string { return format }
 
 // SetWriters overrides stdout/stderr for output capture (used by MCP server).
 // Pass nil to reset to os.Stdout/os.Stderr.
+// Resets reported so each in-process MCP invocation starts clean.
 func SetWriters(out, err io.Writer) {
 	if out != nil {
 		stdout = out
@@ -43,6 +50,7 @@ func SetWriters(out, err io.Writer) {
 	} else {
 		stderr = os.Stderr
 	}
+	reported = false
 }
 
 // Result outputs data in the configured format.
@@ -67,7 +75,8 @@ func Result(data any) {
 	}
 }
 
-// Error outputs a structured error.
+// Error outputs a structured error and marks the invocation as reported so
+// the Execute wrapper does not also print the raw cobra error.
 func Error(code string, message string, status int) {
 	e := map[string]any{
 		"error":   true,
@@ -77,7 +86,11 @@ func Error(code string, message string, status int) {
 	}
 	b, _ := json.MarshalIndent(e, "", "  ")
 	fmt.Fprintln(stderr, string(b))
+	reported = true
 }
+
+// Reported reports whether Error has been called this invocation.
+func Reported() bool { return reported }
 
 // printTable handles any data by marshal/unmarshal to normalize types.
 func printTable(data any) {


### PR DESCRIPTION
## Problem

Cobra parse errors — unknown flag, wrong argument count, unknown subcommand — caused the CLI to exit 1 with **no output**. Users and AI agents received zero feedback on what went wrong.

Example (before this fix):
```
$ sem-ai pipeline list --bogusflag
$ echo $?
1
```
Completely silent. No indication of what failed.

## Root cause

`rootCmd` in `cmd/root.go` sets both `SilenceUsage: true` and `SilenceErrors: true`, which suppresses cobra's built-in error printing. The `Execute()` function then called `os.Exit(1)` on any error without printing it.

## Fix

Two-file change:

**`pkg/output/output.go`** — adds a `reported` package var and `Reported() bool` accessor. `Error()` (which writes structured JSON errors for API failures) sets `reported = true` after writing. `SetWriters()` resets it to `false` so MCP in-process invocations start clean.

**`cmd/root.go`** — in the `if err != nil` block of `Execute()`, checks `output.Reported()` before printing. If false (cobra parse errors, which never call `output.Error`), prints `Error: <message>` to stderr. If true (API errors that already emitted a JSON error), skips the print.

This avoids double-printing: API errors produce exactly one JSON object on stderr; parse errors now produce exactly one human-readable line.

## Verification

After fix:
```
$ ./sem-ai pipeline list --bogusflag
Error: unknown flag: --bogusflag
$ echo $?
1

$ ./sem-ai some-bogus-command
Error: unknown command "some-bogus-command" for "sem-ai"
$ echo $?
1

$ ./sem-ai context switch a b c
Error: accepts at most 1 arg(s), received 3
$ echo $?
1

$ ./sem-ai --help > /dev/null; echo $?
0
```

`--help` still exits 0 with no spurious output. All existing tests pass (`go test ./...`).

---

> ⚠️ Hold — merge after semaphoreio/sem-ai#2 lands.