### PR TITLE
fix(mcp): clear slice flags between tool calls instead of appending "[]"

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -196,17 +196,29 @@ func buildMCPHandler(target *cobra.Command) server.ToolHandlerFunc {
 // resetFlags resets all flag values in the command tree to their defaults.
 // This prevents flag state from bleeding between MCP tool calls.
 func resetFlags(cmd *cobra.Command) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		f.Value.Set(f.DefValue)
-		f.Changed = false
-	})
-	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
-		f.Value.Set(f.DefValue)
-		f.Changed = false
-	})
+	cmd.Flags().VisitAll(resetFlag)
+	cmd.PersistentFlags().VisitAll(resetFlag)
 	for _, child := range cmd.Commands() {
 		resetFlags(child)
 	}
+}
+
+// resetFlag restores one flag to its default.
+//
+// Slice flags need Replace rather than Set. pflag's slice values carry their
+// own "has been set" latch and append on every Set after the first, and the
+// DefValue of an empty slice flag is the literal string "[]" — so Set(DefValue)
+// pushes "[]" onto the slice instead of clearing it, once per MCP tool call.
+// Every slice flag in this tree defaults to nil (asserted by
+// TestSliceFlagsDefaultToEmpty), which is what makes Replace(nil) an exact
+// reset rather than an approximation.
+func resetFlag(f *pflag.Flag) {
+	if sv, ok := f.Value.(pflag.SliceValue); ok {
+		sv.Replace(nil)
+	} else {
+		f.Value.Set(f.DefValue)
+	}
+	f.Changed = false
 }
 
 // executeCobra runs rootCmd with given args, capturing output via SetOut/SetErr.

--- a/cmd/mcp_test.go
+++ b/cmd/mcp_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -65,6 +66,9 @@ func TestResetFlagsAllTypes(t *testing.T) {
 	tags := child.Flags().Lookup("tags")
 	if tags.Changed {
 		t.Error("tags.Changed should be false after reset")
+	}
+	if got := tags.Value.String(); got != "[]" {
+		t.Errorf("tags = %s, want empty", got)
 	}
 }
 
@@ -213,5 +217,68 @@ func TestExtractArgsDescription(t *testing.T) {
 		if !tc.want && desc != "" {
 			t.Errorf("Use=%q: expected empty, got %q", tc.use, desc)
 		}
+	}
+}
+
+// pflag's slice values append on every Set after the first, and an empty
+// slice flag's DefValue is the literal "[]". Resetting with Set therefore
+// grew every slice flag by one bogus "[]" entry per MCP tool call — job_list
+// went out as ?states=[]&states=[] and so on for the life of the server.
+func TestResetFlagsClearsSliceValuesAcrossCalls(t *testing.T) {
+	target, _, err := rootCmd.Find([]string{"job", "list"})
+	if err != nil {
+		t.Fatalf("find job list: %v", err)
+	}
+	states := target.Flags().Lookup("states")
+	if states == nil {
+		t.Fatal("job list has no --states flag")
+	}
+
+	for call := 1; call <= 3; call++ {
+		resetFlags(rootCmd)
+		if got := states.Value.String(); got != "[]" {
+			t.Fatalf("after reset #%d: states = %s, want empty", call, got)
+		}
+	}
+
+	// A reset flag must still accumulate normally once the next call sets it.
+	states.Value.Set("RUNNING")
+	states.Value.Set("QUEUED")
+	if got := states.Value.String(); got != "[RUNNING,QUEUED]" {
+		t.Errorf("states = %s, want [RUNNING,QUEUED]", got)
+	}
+	resetFlags(rootCmd)
+	if got := states.Value.String(); got != "[]" {
+		t.Errorf("after reset: states = %s, want empty", got)
+	}
+}
+
+// resetFlag clears slice flags with Replace(nil) instead of restoring
+// DefValue. That is only an exact reset while every slice flag defaults to
+// empty. Adding one with a real default should fail here, not silently lose it.
+func TestSliceFlagsDefaultToEmpty(t *testing.T) {
+	var offenders []string
+
+	check := func(cmd *cobra.Command, f *pflag.Flag) {
+		if _, ok := f.Value.(pflag.SliceValue); !ok {
+			return
+		}
+		if f.DefValue != "[]" {
+			offenders = append(offenders, fmt.Sprintf("%s --%s (default %s)", cmd.CommandPath(), f.Name, f.DefValue))
+		}
+	}
+
+	var walk func(*cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		cmd.Flags().VisitAll(func(f *pflag.Flag) { check(cmd, f) })
+		cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) { check(cmd, f) })
+		for _, child := range cmd.Commands() {
+			walk(child)
+		}
+	}
+	walk(rootCmd)
+
+	if len(offenders) > 0 {
+		t.Errorf("slice flags with non-empty defaults: %v\nresetFlag clears these to empty — teach it to restore the default first", offenders)
 	}
 }


### PR DESCRIPTION
## Problem

`resetFlags` restores every flag to its default between MCP tool calls with `Value.Set(f.DefValue)`. That is wrong for slice flags on two counts: an empty slice flag's `DefValue` is the literal string `"[]"`, and pflag's slice values carry their own "has been set" latch that makes every `Set` after the first append rather than assign. So each tool call pushes one more `"[]"` onto every slice flag, for the life of the server:

```
after reset #1: []string{"[]"}
after reset #2: []string{"[]", "[]"}
after reset #3: []string{"[]", "[]", "[]"}
```

`job_list` then sends `?states=[]&states=[]…` to the API, and the same applies to `secret create --env`, `task run --param`, `pipeline promote --param`, and `deploy`'s `--env-var` / `--file` / `--subject-user` / `--subject-role`. The plain CLI is unaffected — `resetFlags` has a single caller, `executeCobra`, on the MCP path only.

## Change

Reset slice flags with `pflag.SliceValue.Replace(nil)` instead of `Value.Set(DefValue)`. Non-slice flags keep the existing path verbatim. The two identical `VisitAll` closures collapse into one named `resetFlag`.

Every slice flag in the tree declares a `nil` default, which is what makes `Replace(nil)` an exact reset rather than an approximation — all ten are `StringArrayVar(..., nil, ...)`.

## Verification

- `TestResetFlagsClearsSliceValuesAcrossCalls` — three consecutive resets leave `--states` empty, and a flag still accumulates normally once the next call sets it
- `TestSliceFlagsDefaultToEmpty` — walks the whole command tree and fails if a slice flag is ever declared with a non-empty default, so `Replace(nil)` can't silently drop one later
- `TestResetFlagsAllTypes` asserted only `.Changed` and never the value, which is why this survived; it now checks the value too
- Mutation-checked rather than assumed: restoring the old `Value.Set(DefValue)` fails both guards, reporting `states = [[]]` and `tags = [a,b,[]]`
- `go vet` clean; full suite green under `-count=5`, `-race`, and `-shuffle=on`

Resolves renderedtext/project-tasks#3446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
