### PR TITLE
feat(pfc): add pfc show/apply/delete command group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.html
 .idea/
 *.swp
 *.swo
+junit-*.xml

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ codex plugin marketplace add semaphoreio/sem-ai
 codex plugin add sem-ai@semaphoreio
 ```
 
-The plugin drops every sem-ai skill (debug-pipeline, deploy, fix-flaky, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox, watch-after-push) into your host.
+The plugin drops every sem-ai skill (debug-pipeline, deploy, fix-flaky, gha-to-semaphore, init, manage-infra, probe-agent-environment, project-health, sem-ai-bootstrap, semaphore-blocks, semaphore-ci, semaphore-preflight, semaphore-promotions, semaphore-test-results, semaphore-toolbox, test-intelligence, testbox, watch-after-push) into your host.
 
 Claude Code refreshes registered marketplaces at session start, picks up the new plugin version, and applies it automatically — there is no manifest flag to set for this. To force an immediate refresh:
 
@@ -233,6 +233,16 @@ All analytics commands accept `--project` (auto-detected from git), `--days`, `-
 | `deploy activate <id>` | Activate a target |
 | `deploy deactivate <id>` | Deactivate a target |
 | `deploy delete <id>` | Delete a target |
+
+### Pre-flight checks
+
+Commands that run at pipeline initialization, before any block. One check per organization, one per project — `--project` selects the project check, omitting it selects the organization-wide one.
+
+| Command | Description |
+|---------|-------------|
+| `pfc show [--project <p>]` | Show the check (commands, secrets, agent) |
+| `pfc apply [--project <p>]` | Create or replace the check, from flags or `--from-file` |
+| `pfc delete [--project <p>]` | Remove the check |
 
 ### Secrets
 

--- a/assets/plugin/skills/debug-pipeline/SKILL.md
+++ b/assets/plugin/skills/debug-pipeline/SKILL.md
@@ -81,4 +81,5 @@ sem-ai test summary --pipeline <id>  # verify
 | Pipeline stuck `initializing` | YAML error | `sem-ai yaml validate --file .semaphore/semaphore.yml` |
 | `result_reason: "stuck"` | No agent available | `sem-ai agent types` |
 | All blocks empty | Compile failed | `sem-ai troubleshoot pipeline <id>` |
+| Failed pipeline, no blocks ever scheduled | Pre-flight check failed at init | `sem-ai pfc show [--project <name>]`, then the `semaphore-preflight` skill |
 | `cache` errors | Cache not configured | Environment issue, not code |

--- a/assets/plugin/skills/semaphore-preflight/SKILL.md
+++ b/assets/plugin/skills/semaphore-preflight/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: semaphore-preflight
+description: Diagnose and configure Semaphore pre-flight checks — the organization- and project-level commands that run at pipeline initialization, before any block. Use when a pipeline or promotion fails at init with no block output, when the user asks why nothing ran, or when they want to read, add, change, or remove a gate that applies to every workflow in an organization or project.
+---
+
+# Semaphore pre-flight checks
+
+## The model in three sentences
+
+A **pre-flight check** is a list of shell commands Semaphore runs in an init job at the start of *every* workflow in a scope, before any block is scheduled. There are two scopes — one check per organization and one per project — and both run, so a pipeline passes only if neither fails. A non-zero exit stops the pipeline there, which is why the symptom is a failed pipeline with **no block output at all**.
+
+| Scope | Applies to | Read it with |
+|---|---|---|
+| Organization | Every pipeline in the org, CI and promotions alike | `sem-ai pfc show` |
+| Project | Every pipeline in that one project | `sem-ai pfc show --project <name>` |
+
+Pre-flight checks are **not** in `.semaphore/semaphore.yml`. Editing YAML cannot disable them.
+
+## Diagnose — is this actually a pre-flight failure?
+
+The tell is a pipeline that failed while its block list is empty or never started.
+
+```bash
+# 1. What failed, and did any block run?
+sem-ai diagnose <workflow-id>
+sem-ai pipeline show <pipeline-id>     # blocks: [] or every block still pending
+
+# 2. Server-side reason for a pipeline that never got going.
+sem-ai troubleshoot pipeline <pipeline-id>
+
+# 3. If an init job is listed, its log holds the check's own output.
+sem-ai job list --states FINISHED
+sem-ai job log <job-id>
+```
+
+Rule of thumb:
+
+| Symptom | Likely cause | Next step |
+|---|---|---|
+| Failed pipeline, zero blocks, no test results | Pre-flight check failed | `sem-ai pfc show` then `sem-ai pfc show --project <name>` |
+| Pipeline stuck `initializing` | Invalid pipeline YAML | `sem-ai yaml validate --file .semaphore/semaphore.yml` |
+| Blocks ran, one failed | Ordinary job failure | `debug-pipeline` skill |
+| Fails only on promoted pipelines | Check keyed on `SEMAPHORE_PIPELINE_PROMOTION` | read the commands in `sem-ai pfc show` |
+
+Check **both** scopes before concluding a project is clean — an org-level check fails project pipelines that have no check of their own.
+
+## Read the current check
+
+```bash
+sem-ai pfc show                        # organization-wide
+sem-ai pfc show --project my-project   # one project
+```
+
+Returns the `commands`, the `secrets` they are allowed to use, the `agent` the init job runs on, and who last changed it (`requester_id`, `updated_at`). "No pre-flight check configured for this organization/project" means the scope has none — that is a valid state, not an error to work around.
+
+## Change it
+
+`apply` **replaces the whole check** — it does not merge. Whatever you send becomes the check in full, and it takes effect on the next workflow in that scope, for everyone.
+
+So: read first, show the user the difference, then apply.
+
+```bash
+# 1. What is there now?
+sem-ai pfc show --project my-project
+
+# 2. Apply the full intended check (commands run in the order given).
+sem-ai pfc apply --project my-project \
+  --command checkout \
+  --command './scripts/security-gate.sh' \
+  --secret scanner-token
+
+# 3. Confirm, then prove it on a real run.
+sem-ai pfc show --project my-project
+sem-ai workflow run --project my-project
+```
+
+Pin the init job's agent when the commands need a particular image:
+
+```bash
+sem-ai pfc apply --command './scripts/gate.sh' \
+  --machine-type e2-standard-2 --os-image ubuntu2204
+```
+
+For anything longer than a couple of commands, keep the spec in a file and apply that — it is reviewable and re-appliable:
+
+```yaml
+# pfc.yml
+commands:
+  - checkout
+  - ./scripts/security-gate.sh
+secrets:
+  - scanner-token
+agent:
+  machine_type: e2-standard-2
+  os_image: ubuntu2204
+```
+
+```bash
+sem-ai pfc apply --project my-project --from-file pfc.yml
+```
+
+`--from-file` accepts YAML or JSON and cannot be combined with `--command` / `--secret` / `--machine-type` / `--os-image`. Scope always comes from `--project`, never from the file.
+
+## Remove it
+
+```bash
+sem-ai pfc delete --project my-project   # drop the project check
+sem-ai pfc delete                        # drop the organization-wide check
+```
+
+Deleting one scope leaves the other in force. If a project's pipelines still fail at init after deleting the project check, the org-level check is the one failing them.
+
+## Writing a check that is easy to live with
+
+- Commands run in a plain init job, so `checkout` first if the check reads the repo.
+- Standard env vars are available — `SEMAPHORE_PROJECT_NAME`, `SEMAPHORE_GIT_BRANCH`, and `SEMAPHORE_PIPELINE_PROMOTION` (set when the init is for a promoted pipeline, useful for gating deploys only).
+- Exit non-zero **only** for conditions the user genuinely wants to block. A flaky network call in a pre-flight check takes down every pipeline in the scope, including the one that would fix it.
+- Anything that needs credentials must name them in `secrets`; the check cannot reach a secret it was not given.
+
+## Errors you will see
+
+| Response | Meaning |
+|---|---|
+| `no pre-flight check configured for this organization/project` | Nothing set at that scope |
+| `permission denied: this requires the ...pre_flight_checks.manage permission` | The token can read but not change checks — ask an org owner |
+| `...feature is not enabled for your organization` | Pre-flight checks are not on this plan/organization |
+| `invalid pre-flight check: ...` | The server rejected the spec — the message names the field |
+
+## Boundaries
+
+- Failures *inside* a block are ordinary job failures — use the `debug-pipeline` skill.
+- Promotion gating rules (`auto_promote`, deployment targets, who may promote) are the `semaphore-promotions` skill; a pre-flight check is a second, independent gate on top of them.
+- Block, task, and job structure inside the pipeline is the `semaphore-blocks` skill.

--- a/assets/plugin/skills/semaphore-promotions/SKILL.md
+++ b/assets/plugin/skills/semaphore-promotions/SKILL.md
@@ -119,12 +119,12 @@ Promoted pipelines are subject to **organization and project pre-flight checks**
 
 | Pre-flight check | Where configured | Scope |
 |---|---|---|
-| Organization-level | Org Settings → Initialization jobs → Pre-flight checks | Every pipeline in the org (CI and every promoted pipeline) |
-| Project-level | Project Settings → Pre-flight checks | Every pipeline in that project |
+| Organization-level | `sem-ai pfc show` / Org Settings → Initialization jobs → Pre-flight checks | Every pipeline in the org (CI and every promoted pipeline) |
+| Project-level | `sem-ai pfc show --project <name>` / Project Settings → Pre-flight checks | Every pipeline in that project |
 
 Important:
 
-- Pre-flight checks are **not in pipeline YAML**. They live in Semaphore Settings (UI / API). YAML changes won't disable them.
+- Pre-flight checks are **not in pipeline YAML**. They are an org/project setting, read and written with `sem-ai pfc` or in the UI. YAML changes won't disable them.
 - Checks are shell commands run in an init job. Can bind secrets, have standard env vars (`SEMAPHORE_PROJECT_NAME`, `SEMAPHORE_GIT_BRANCH`, etc.).
 - The `SEMAPHORE_PIPELINE_PROMOTION` env var is set when the check runs as part of a *promoted* pipeline init — use it to skip-or-tighten checks for promotions specifically.
 - Failure mode: hard fail at init. The pipeline shows up with a failed initialization job and no blocks ever scheduled.
@@ -140,7 +140,7 @@ Common uses:
 Two non-obvious behaviors for the agent to remember:
 
 - **A promotion that "didn't fire" might have started but failed at pre-flight.** Check `sem-ai pipeline show <promoted-pipeline-id>` for an init-job failure with `result: failed` and a near-zero block count.
-- **Disabling a pre-flight check is an org/project setting change**, not a YAML edit. The user must do it in the Semaphore UI (or via API).
+- **Disabling a pre-flight check is an org/project setting change**, not a YAML edit. Do it with `sem-ai pfc delete [--project <name>]`, or narrow the check with `sem-ai pfc apply` — see the `semaphore-preflight` skill before changing one, since the check applies to every workflow in that scope.
 
 ## Inspecting and triggering with sem-ai
 
@@ -153,6 +153,8 @@ Two non-obvious behaviors for the agent to remember:
 | Block a target temporarily | `sem-ai deploy deactivate <target-id>` |
 | Re-enable | `sem-ai deploy activate <target-id>` |
 | Create a new target | `sem-ai deploy create --name <n> --url <u> [...rules]` |
+| Read the pre-flight check that gates the promoted pipeline | `sem-ai pfc show [--project <name>]` |
+| Change or remove that check | `sem-ai pfc apply` / `sem-ai pfc delete` (see `semaphore-preflight`) |
 
 ## Diagnostic playbook for the agent
 
@@ -164,7 +166,7 @@ Two non-obvious behaviors for the agent to remember:
 
 **"What changed between two deploys?"** → `sem-ai deploy history <target-id>` lists each promotion with workflow IDs and commits. Pick two SHAs and `git log A..B`.
 
-**"Promotion shows as failed with no block output"** → likely a **pre-flight check** failure at init time. The pipeline never reached the blocks. Inspect the init job for the failure message; remediation is in Semaphore Settings, not YAML.
+**"Promotion shows as failed with no block output"** → likely a **pre-flight check** failure at init time. The pipeline never reached the blocks. Inspect the init job for the failure message, then read the check that ran with `sem-ai pfc show [--project <name>]`. Remediation is at the org/project level, not YAML — hand off to the `semaphore-preflight` skill.
 
 ## Boundaries
 

--- a/cmd/pfc.go
+++ b/cmd/pfc.go
@@ -1,0 +1,402 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/semaphoreio/sem-ai/pkg/client"
+	"github.com/semaphoreio/sem-ai/pkg/config"
+	"github.com/semaphoreio/sem-ai/pkg/output"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const pfcKind = "pre_flight_checks"
+
+var pfcCmd = &cobra.Command{
+	Use:   "pfc",
+	Short: "Pre-flight check operations: read, set, and remove init-time gate commands",
+	Long: `Pre-flight checks are shell commands Semaphore runs during pipeline
+initialization, before any block starts. They exist at two scopes: one
+organization-wide check that applies to every pipeline in the organization, and
+one per project. Both run; either can stop a pipeline.
+
+A failing pre-flight check aborts the pipeline before any block is scheduled, so
+the symptom is a failed pipeline with no block output.
+
+Scope follows --project: pass it for the project-level check, omit it for the
+organization-wide one.`,
+}
+
+// pfcScope is the resolved target of a pre-flight check call: a project id, or
+// empty for the organization-wide check.
+type pfcScope struct {
+	projectID string
+}
+
+// resolvePFCScope turns the --project flag into a scope. Unlike most commands,
+// an empty flag is not "detect the project from the git remote" — it selects
+// the organization-wide check, so nothing is auto-detected here.
+func resolvePFCScope(projectFlag string) (pfcScope, error) {
+	if strings.TrimSpace(projectFlag) == "" {
+		return pfcScope{}, nil
+	}
+	id, err := resolveProjectID(projectFlag)
+	if err != nil {
+		return pfcScope{}, err
+	}
+	return pfcScope{projectID: id}, nil
+}
+
+func (s pfcScope) isProject() bool { return s.projectID != "" }
+
+// name is the scope word used in messages and in permission names.
+func (s pfcScope) name() string {
+	if s.isProject() {
+		return "project"
+	}
+	return "organization"
+}
+
+// params returns the query parameters that pin the request to this scope: none
+// for the organization-wide check.
+func (s pfcScope) params() url.Values {
+	if !s.isProject() {
+		return nil
+	}
+	return url.Values{"project_id": {s.projectID}}
+}
+
+// permission names the RBAC permission the API checks for an action, e.g.
+// project.pre_flight_checks.manage.
+func (s pfcScope) permission(action string) string {
+	return fmt.Sprintf("%s.pre_flight_checks.%s", s.name(), action)
+}
+
+// pfcSpec is the pre-flight check itself: the commands to run, the secrets they
+// need, and the agent to run them on. It is both the PATCH body and the
+// --from-file schema, hence the two sets of struct tags.
+type pfcSpec struct {
+	Commands []string  `json:"commands" yaml:"commands"`
+	Secrets  []string  `json:"secrets" yaml:"secrets"`
+	Agent    *pfcAgent `json:"agent,omitempty" yaml:"agent,omitempty"`
+}
+
+type pfcAgent struct {
+	MachineType string `json:"machine_type" yaml:"machine_type"`
+	OsImage     string `json:"os_image,omitempty" yaml:"os_image,omitempty"`
+}
+
+// pfcApplyFlags holds the flag values for apply. The spec comes either from the
+// inline flags or from --from-file, never both.
+type pfcApplyFlags struct {
+	project     string
+	commands    []string
+	secrets     []string
+	machineType string
+	osImage     string
+	fromFile    string
+}
+
+func (f *pfcApplyFlags) hasInlineSpec() bool {
+	return len(f.commands) > 0 || len(f.secrets) > 0 || f.machineType != "" || f.osImage != ""
+}
+
+// spec resolves the flags into the check to apply, rejecting the two ambiguous
+// input combinations (both sources, neither source) and any spec with no
+// commands — a check that runs nothing is never what the caller meant.
+func (f *pfcApplyFlags) spec() (*pfcSpec, error) {
+	spec, err := f.readSpec()
+	if err != nil {
+		return nil, err
+	}
+	if len(spec.Commands) == 0 {
+		return nil, fmt.Errorf("a pre-flight check needs at least one command")
+	}
+	if spec.Secrets == nil {
+		spec.Secrets = []string{}
+	}
+	return spec, nil
+}
+
+func (f *pfcApplyFlags) readSpec() (*pfcSpec, error) {
+	switch {
+	case f.fromFile != "" && f.hasInlineSpec():
+		return nil, fmt.Errorf("--from-file cannot be combined with --command/--secret/--machine-type/--os-image; supply the spec one way or the other")
+	case f.fromFile != "":
+		return loadPFCSpecFile(f.fromFile)
+	case !f.hasInlineSpec():
+		return nil, fmt.Errorf("no spec given: pass --command (repeatable, plus optional --secret/--machine-type/--os-image) or --from-file <path>")
+	}
+
+	spec := &pfcSpec{Commands: f.commands, Secrets: f.secrets}
+	if f.machineType != "" || f.osImage != "" {
+		spec.Agent = &pfcAgent{MachineType: f.machineType, OsImage: f.osImage}
+	}
+	return spec, nil
+}
+
+// loadPFCSpecFile reads a full spec from a YAML or JSON file. The format is
+// sniffed by parsing rather than by extension: JSON first, then YAML, so a
+// mis-named file still loads and the reported error is the YAML one (the more
+// common format for this file).
+func loadPFCSpecFile(path string) (*pfcSpec, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("--from-file %s: %w", path, err)
+	}
+
+	var spec pfcSpec
+	if json.Unmarshal(raw, &spec) == nil {
+		return &spec, nil
+	}
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		return nil, fmt.Errorf("--from-file %s: not valid YAML or JSON: %w", path, err)
+	}
+	return &spec, nil
+}
+
+// pfcServerMessage pulls the human-readable message out of an API error body,
+// which may key it as "message" or "error".
+func pfcServerMessage(body []byte) string {
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return ""
+	}
+	for _, key := range []string{"message", "error"} {
+		if s, ok := payload[key].(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// pfcErrorMessage turns a non-2xx response into something a caller can act on:
+// the server's own words when the feature is off, a named missing permission on
+// a 401, and "not configured" rather than a bare 404.
+func pfcErrorMessage(resp *client.Response, scope pfcScope, action string) string {
+	server := pfcServerMessage(resp.Body)
+	if strings.Contains(strings.ToLower(server), "not enabled") {
+		return server
+	}
+
+	switch resp.StatusCode {
+	case 404:
+		return fmt.Sprintf("no pre-flight check configured for this %s", scope.name())
+	case 401, 403:
+		return fmt.Sprintf("permission denied: this requires the %s permission", scope.permission(action))
+	case 422:
+		if server != "" {
+			return fmt.Sprintf("invalid pre-flight check: %s", server)
+		}
+		return fmt.Sprintf("invalid pre-flight check: %s", strings.TrimSpace(string(resp.Body)))
+	}
+	return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body))
+}
+
+// pfcFail reports an API failure through output and returns the error cobra
+// propagates to the exit code.
+func pfcFail(resp *client.Response, scope pfcScope, action string) error {
+	output.Error("api_error", pfcErrorMessage(resp, scope, action), resp.StatusCode)
+	return fmt.Errorf("API returned %d", resp.StatusCode)
+}
+
+var pfcShowProjectFlag string
+
+var pfcShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show the pre-flight check for the organization, or for one project",
+	Long: `Show the pre-flight check — the commands, secrets, and agent used by the init
+job that runs before any block in a pipeline.
+
+With --project, shows that project's check; without it, the organization-wide
+one. Reports "no pre-flight check configured" when the scope has none.`,
+	Args: cobra.NoArgs,
+	Example: `  # the organization-wide check
+  sem-ai pfc show
+
+  # one project's check
+  sem-ai pfc show --project my-project`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured; run 'sem-ai connect' first")
+		}
+		scope, err := resolvePFCScope(pfcShowProjectFlag)
+		if err != nil {
+			output.Error("project_error", err.Error(), 1)
+			return err
+		}
+
+		c := client.New()
+		resp, err := c.ListWithParams(pfcKind, scope.params())
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		if resp.StatusCode != 200 {
+			return pfcFail(resp, scope, "view")
+		}
+
+		var result any
+		json.Unmarshal(resp.Body, &result)
+		output.Result(result)
+		return nil
+	},
+}
+
+var pfcApply = &pfcApplyFlags{}
+
+var pfcApplyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Create or replace the pre-flight check — the commands that run before every workflow in the scope",
+	Long: `Create or replace the pre-flight check for the organization (default) or for
+one project (--project).
+
+This is a privileged change: the commands given here run at the start of every
+workflow in that scope, and a non-zero exit stops the pipeline before any block
+runs. Show the current check (sem-ai pfc show) and confirm the difference before
+applying.
+
+Apply replaces the whole check, it does not merge — the commands, secrets, and
+agent sent become the check in full.
+
+The spec comes from flags or from a file, never both:
+
+  flags       --command (repeatable, order preserved), --secret (repeatable),
+              --machine-type, --os-image
+  --from-file a YAML or JSON file with the same fields:
+
+                commands:
+                  - checkout
+                  - make security-scan
+                secrets:
+                  - scanner-token
+                agent:
+                  machine_type: e2-standard-2
+                  os_image: ubuntu2204
+
+Scope always comes from --project; a project_id inside the file is ignored.`,
+	Args: cobra.NoArgs,
+	Example: `  # organization-wide gate, two commands, one secret
+  sem-ai pfc apply --command checkout --command 'make security-scan' --secret scanner-token
+
+  # project-level gate on a specific agent
+  sem-ai pfc apply --project my-project \
+    --command './scripts/gate.sh' \
+    --machine-type e2-standard-2 --os-image ubuntu2204
+
+  # full spec from a file
+  sem-ai pfc apply --project my-project --from-file pfc.yml`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured; run 'sem-ai connect' first")
+		}
+		spec, err := pfcApply.spec()
+		if err != nil {
+			output.Error("flag_error", err.Error(), 2)
+			return err
+		}
+		scope, err := resolvePFCScope(pfcApply.project)
+		if err != nil {
+			output.Error("project_error", err.Error(), 1)
+			return err
+		}
+
+		body := map[string]any{"commands": spec.Commands, "secrets": spec.Secrets}
+		if spec.Agent != nil {
+			body["agent"] = spec.Agent
+		}
+		if scope.isProject() {
+			body["project_id"] = scope.projectID
+		}
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			output.Error("format_error", err.Error(), 1)
+			return err
+		}
+
+		c := client.New()
+		resp, err := c.PatchWithParams(pfcKind, nil, bodyBytes)
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		if resp.StatusCode != 200 && resp.StatusCode != 201 {
+			return pfcFail(resp, scope, "manage")
+		}
+
+		var result any
+		if err := json.Unmarshal(resp.Body, &result); err != nil {
+			output.Result(map[string]string{"status": "applied", "scope": scope.name()})
+			return nil
+		}
+		output.Result(result)
+		return nil
+	},
+}
+
+var pfcDeleteProjectFlag string
+
+var pfcDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Remove the pre-flight check from the organization, or from one project",
+	Long: `Remove the pre-flight check for the organization (default) or for one project
+(--project). Pipelines in that scope stop running the check from the next
+initialization onwards.
+
+The other scope is untouched: deleting a project's check leaves the
+organization-wide one in force for that project.`,
+	Args: cobra.NoArgs,
+	Example: `  # drop the organization-wide check
+  sem-ai pfc delete
+
+  # drop one project's check
+  sem-ai pfc delete --project my-project`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured; run 'sem-ai connect' first")
+		}
+		scope, err := resolvePFCScope(pfcDeleteProjectFlag)
+		if err != nil {
+			output.Error("project_error", err.Error(), 1)
+			return err
+		}
+
+		c := client.New()
+		resp, err := c.DeletePathWithParams(pfcKind, scope.params())
+		if err != nil {
+			output.Error("api_error", err.Error(), 1)
+			return err
+		}
+		if resp.StatusCode != 200 && resp.StatusCode != 204 {
+			return pfcFail(resp, scope, "manage")
+		}
+
+		result := map[string]string{"status": "deleted", "scope": scope.name()}
+		if scope.isProject() {
+			result["project_id"] = scope.projectID
+		}
+		output.Result(result)
+		return nil
+	},
+}
+
+func init() {
+	pfcShowCmd.Flags().StringVar(&pfcShowProjectFlag, "project", "", "project name or ID; omit for the organization-wide check")
+	pfcDeleteCmd.Flags().StringVar(&pfcDeleteProjectFlag, "project", "", "project name or ID; omit for the organization-wide check")
+
+	pfcApplyCmd.Flags().StringVar(&pfcApply.project, "project", "", "project name or ID; omit for the organization-wide check")
+	pfcApplyCmd.Flags().StringArrayVar(&pfcApply.commands, "command", nil, "shell command to run at pipeline init; repeatable, order preserved")
+	pfcApplyCmd.Flags().StringArrayVar(&pfcApply.secrets, "secret", nil, "name of a secret to expose to the commands; repeatable")
+	pfcApplyCmd.Flags().StringVar(&pfcApply.machineType, "machine-type", "", "agent machine type for the init job (e.g. e2-standard-2)")
+	pfcApplyCmd.Flags().StringVar(&pfcApply.osImage, "os-image", "", "agent OS image for the init job (e.g. ubuntu2204)")
+	pfcApplyCmd.Flags().StringVar(&pfcApply.fromFile, "from-file", "", "path to a YAML or JSON file holding the full spec; mutually exclusive with the spec flags")
+
+	pfcCmd.AddCommand(pfcShowCmd)
+	pfcCmd.AddCommand(pfcApplyCmd)
+	pfcCmd.AddCommand(pfcDeleteCmd)
+	rootCmd.AddCommand(pfcCmd)
+}

--- a/cmd/pfc.go
+++ b/cmd/pfc.go
@@ -31,8 +31,6 @@ Scope follows --project: pass it for the project-level check, omit it for the
 organization-wide one.`,
 }
 
-// pfcScope is the resolved target of a pre-flight check call: a project id, or
-// empty for the organization-wide check.
 type pfcScope struct {
 	projectID string
 }
@@ -53,7 +51,6 @@ func resolvePFCScope(projectFlag string) (pfcScope, error) {
 
 func (s pfcScope) isProject() bool { return s.projectID != "" }
 
-// name is the scope word used in messages and in permission names.
 func (s pfcScope) name() string {
 	if s.isProject() {
 		return "project"
@@ -61,8 +58,6 @@ func (s pfcScope) name() string {
 	return "organization"
 }
 
-// params returns the query parameters that pin the request to this scope: none
-// for the organization-wide check.
 func (s pfcScope) params() url.Values {
 	if !s.isProject() {
 		return nil
@@ -70,15 +65,10 @@ func (s pfcScope) params() url.Values {
 	return url.Values{"project_id": {s.projectID}}
 }
 
-// permission names the RBAC permission the API checks for an action, e.g.
-// project.pre_flight_checks.manage.
 func (s pfcScope) permission(action string) string {
 	return fmt.Sprintf("%s.pre_flight_checks.%s", s.name(), action)
 }
 
-// pfcSpec is the pre-flight check itself: the commands to run, the secrets they
-// need, and the agent to run them on. It is both the PATCH body and the
-// --from-file schema, hence the two sets of struct tags.
 type pfcSpec struct {
 	Commands []string  `json:"commands" yaml:"commands"`
 	Secrets  []string  `json:"secrets" yaml:"secrets"`
@@ -90,8 +80,6 @@ type pfcAgent struct {
 	OsImage     string `json:"os_image,omitempty" yaml:"os_image,omitempty"`
 }
 
-// pfcApplyFlags holds the flag values for apply. The spec comes either from the
-// inline flags or from --from-file, never both.
 type pfcApplyFlags struct {
 	project     string
 	commands    []string
@@ -105,9 +93,6 @@ func (f *pfcApplyFlags) hasInlineSpec() bool {
 	return len(f.commands) > 0 || len(f.secrets) > 0 || f.machineType != "" || f.osImage != ""
 }
 
-// spec resolves the flags into the check to apply, rejecting the two ambiguous
-// input combinations (both sources, neither source) and any spec with no
-// commands — a check that runs nothing is never what the caller meant.
 func (f *pfcApplyFlags) spec() (*pfcSpec, error) {
 	spec, err := f.readSpec()
 	if err != nil {
@@ -159,8 +144,6 @@ func loadPFCSpecFile(path string) (*pfcSpec, error) {
 	return &spec, nil
 }
 
-// pfcServerMessage pulls the human-readable message out of an API error body,
-// which may key it as "message" or "error".
 func pfcServerMessage(body []byte) string {
 	var payload map[string]any
 	if err := json.Unmarshal(body, &payload); err != nil {
@@ -174,9 +157,6 @@ func pfcServerMessage(body []byte) string {
 	return ""
 }
 
-// pfcErrorMessage turns a non-2xx response into something a caller can act on:
-// the server's own words when the feature is off, a named missing permission on
-// a 401, and "not configured" rather than a bare 404.
 func pfcErrorMessage(resp *client.Response, scope pfcScope, action string) string {
 	server := pfcServerMessage(resp.Body)
 	if strings.Contains(strings.ToLower(server), "not enabled") {
@@ -197,8 +177,6 @@ func pfcErrorMessage(resp *client.Response, scope pfcScope, action string) strin
 	return fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body))
 }
 
-// pfcFail reports an API failure through output and returns the error cobra
-// propagates to the exit code.
 func pfcFail(resp *client.Response, scope pfcScope, action string) error {
 	output.Error("api_error", pfcErrorMessage(resp, scope, action), resp.StatusCode)
 	return fmt.Errorf("API returned %d", resp.StatusCode)

--- a/cmd/pfc_test.go
+++ b/cmd/pfc_test.go
@@ -1,0 +1,572 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/semaphoreio/sem-ai/pkg/client"
+)
+
+// pfcMock wires the shared API mock and clears the pfc flag vars, which persist
+// between tests because RunE is called directly (no cobra flag reset).
+func pfcMock(t *testing.T, handler http.HandlerFunc) (reqs *[]capturedReq, stdout, stderr *bytes.Buffer) {
+	t.Helper()
+	resetPFCFlags()
+	t.Cleanup(resetPFCFlags)
+	return apiMock(t, handler)
+}
+
+func resetPFCFlags() {
+	pfcShowProjectFlag, pfcDeleteProjectFlag = "", ""
+	*pfcApply = pfcApplyFlags{}
+}
+
+// writeSpecFile drops a --from-file fixture in a temp dir and returns its path.
+func writeSpecFile(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+// decodeError parses the structured error the output package wrote to stderr.
+func decodeError(t *testing.T, stderr *bytes.Buffer) map[string]any {
+	t.Helper()
+	var e map[string]any
+	if err := json.Unmarshal(stderr.Bytes(), &e); err != nil {
+		t.Fatalf("stderr is not a structured error: %v (got %q)", err, stderr.String())
+	}
+	return e
+}
+
+// projectLookupHandler answers the resolveProjectID lookup for one project name.
+func projectLookupHandler(t *testing.T, name, id string, then http.HandlerFunc) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/api/v1alpha/projects/"+name {
+			writeJSON(w, 200, map[string]any{"metadata": map[string]any{"id": id, "name": name}})
+			return
+		}
+		then(w, r)
+	}
+}
+
+// ---- spec resolution: flags, --from-file, and the two ambiguous cases -------
+
+func TestPFCSpec_FlagsOnly(t *testing.T) {
+	f := &pfcApplyFlags{
+		commands:    []string{"checkout", "make security-scan"},
+		secrets:     []string{"scanner-token"},
+		machineType: "e2-standard-2",
+		osImage:     "ubuntu2204",
+	}
+
+	spec, err := f.spec()
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+	if len(spec.Commands) != 2 || spec.Commands[0] != "checkout" || spec.Commands[1] != "make security-scan" {
+		t.Errorf("commands = %v, want [checkout, make security-scan] in order", spec.Commands)
+	}
+	if len(spec.Secrets) != 1 || spec.Secrets[0] != "scanner-token" {
+		t.Errorf("secrets = %v, want [scanner-token]", spec.Secrets)
+	}
+	if spec.Agent == nil {
+		t.Fatal("agent = nil, want machine type and OS image")
+	}
+	if spec.Agent.MachineType != "e2-standard-2" || spec.Agent.OsImage != "ubuntu2204" {
+		t.Errorf("agent = %+v, want e2-standard-2/ubuntu2204", *spec.Agent)
+	}
+}
+
+func TestPFCSpec_FlagsWithoutAgentOmitsAgent(t *testing.T) {
+	f := &pfcApplyFlags{commands: []string{"./gate.sh"}}
+
+	spec, err := f.spec()
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+	if spec.Agent != nil {
+		t.Errorf("agent = %+v, want nil so the server picks its default", *spec.Agent)
+	}
+	if spec.Secrets == nil {
+		t.Error("secrets = nil, want an empty slice so apply clears previously bound secrets")
+	}
+}
+
+func TestPFCSpec_FromFileYAML(t *testing.T) {
+	path := writeSpecFile(t, "pfc.yml", `commands:
+  - checkout
+  - make security-scan
+secrets:
+  - scanner-token
+agent:
+  machine_type: e2-standard-2
+  os_image: ubuntu2204
+`)
+	f := &pfcApplyFlags{fromFile: path}
+
+	spec, err := f.spec()
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+	if len(spec.Commands) != 2 || spec.Commands[1] != "make security-scan" {
+		t.Errorf("commands = %v, want [checkout, make security-scan]", spec.Commands)
+	}
+	if len(spec.Secrets) != 1 || spec.Secrets[0] != "scanner-token" {
+		t.Errorf("secrets = %v, want [scanner-token]", spec.Secrets)
+	}
+	if spec.Agent == nil || spec.Agent.MachineType != "e2-standard-2" || spec.Agent.OsImage != "ubuntu2204" {
+		t.Errorf("agent = %+v, want e2-standard-2/ubuntu2204", spec.Agent)
+	}
+}
+
+func TestPFCSpec_FromFileJSON(t *testing.T) {
+	path := writeSpecFile(t, "pfc.json", `{
+  "commands": ["checkout", "make security-scan"],
+  "secrets": ["scanner-token"],
+  "agent": {"machine_type": "e1-standard-4", "os_image": "ubuntu2004"}
+}`)
+	f := &pfcApplyFlags{fromFile: path}
+
+	spec, err := f.spec()
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+	if len(spec.Commands) != 2 || spec.Commands[0] != "checkout" {
+		t.Errorf("commands = %v, want [checkout, make security-scan]", spec.Commands)
+	}
+	if spec.Agent == nil || spec.Agent.MachineType != "e1-standard-4" || spec.Agent.OsImage != "ubuntu2004" {
+		t.Errorf("agent = %+v, want e1-standard-4/ubuntu2004", spec.Agent)
+	}
+}
+
+func TestPFCSpec_FromFileAndFlagsIsAnError(t *testing.T) {
+	path := writeSpecFile(t, "pfc.yml", "commands:\n  - checkout\n")
+	f := &pfcApplyFlags{fromFile: path, commands: []string{"./gate.sh"}}
+
+	_, err := f.spec()
+	if err == nil {
+		t.Fatal("expected an error when both --from-file and spec flags are given")
+	}
+	if !strings.Contains(err.Error(), "--from-file cannot be combined") {
+		t.Errorf("error = %q, want it to name the conflict", err)
+	}
+}
+
+func TestPFCSpec_NeitherFileNorFlagsIsAnError(t *testing.T) {
+	f := &pfcApplyFlags{project: "my-project"}
+
+	_, err := f.spec()
+	if err == nil {
+		t.Fatal("expected an error when no spec is given")
+	}
+	for _, want := range []string{"--command", "--from-file"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to mention %s", err, want)
+		}
+	}
+}
+
+func TestPFCSpec_AgentFlagsWithoutCommandIsAnError(t *testing.T) {
+	f := &pfcApplyFlags{machineType: "e2-standard-2"}
+
+	_, err := f.spec()
+	if err == nil {
+		t.Fatal("expected an error: an agent with no commands is not a check")
+	}
+	if !strings.Contains(err.Error(), "at least one command") {
+		t.Errorf("error = %q, want it to ask for a command", err)
+	}
+}
+
+func TestPFCSpec_FileWithNoCommandsIsAnError(t *testing.T) {
+	path := writeSpecFile(t, "pfc.yml", "secrets:\n  - scanner-token\n")
+	f := &pfcApplyFlags{fromFile: path}
+
+	_, err := f.spec()
+	if err == nil {
+		t.Fatal("expected an error for a file with no commands")
+	}
+	if !strings.Contains(err.Error(), "at least one command") {
+		t.Errorf("error = %q, want it to ask for a command", err)
+	}
+}
+
+func TestPFCSpec_MissingFileIsAnError(t *testing.T) {
+	f := &pfcApplyFlags{fromFile: filepath.Join(t.TempDir(), "absent.yml")}
+
+	_, err := f.spec()
+	if err == nil {
+		t.Fatal("expected an error for a missing --from-file path")
+	}
+	if !strings.Contains(err.Error(), "--from-file") {
+		t.Errorf("error = %q, want it to name the flag", err)
+	}
+}
+
+func TestPFCSpec_UnparseableFileIsAnError(t *testing.T) {
+	path := writeSpecFile(t, "pfc.yml", "commands:\n\t- broken tab indent\n")
+	f := &pfcApplyFlags{fromFile: path}
+
+	_, err := f.spec()
+	if err == nil {
+		t.Fatal("expected an error for a file that is neither YAML nor JSON")
+	}
+	if !strings.Contains(err.Error(), "not valid YAML or JSON") {
+		t.Errorf("error = %q, want it to say the file could not be parsed", err)
+	}
+}
+
+// ---- scope: --project present or absent shapes the request ------------------
+
+func TestPFCShow_OrganizationScopeSendsNoProjectID(t *testing.T) {
+	reqs, stdout, _ := pfcMock(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 200, map[string]any{
+			"commands":     []string{"checkout"},
+			"secrets":      []string{},
+			"requester_id": "u1",
+		})
+	})
+
+	if err := pfcShowCmd.RunE(pfcShowCmd, nil); err != nil {
+		t.Fatalf("pfc show: %v", err)
+	}
+
+	get := find(t, reqs, "GET", "/api/v1alpha/pre_flight_checks")
+	if len(get.Query) != 0 {
+		t.Errorf("query = %v, want none for organization scope", get.Query)
+	}
+	if !strings.Contains(stdout.String(), "checkout") {
+		t.Errorf("stdout = %q, want the check body", stdout.String())
+	}
+}
+
+func TestPFCShow_ProjectScopeResolvesNameToID(t *testing.T) {
+	reqs, _, _ := pfcMock(t, projectLookupHandler(t, "my-project", "proj-uuid",
+		func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{"commands": []string{"checkout"}})
+		}))
+
+	pfcShowProjectFlag = "my-project"
+	if err := pfcShowCmd.RunE(pfcShowCmd, nil); err != nil {
+		t.Fatalf("pfc show: %v", err)
+	}
+
+	get := find(t, reqs, "GET", "/api/v1alpha/pre_flight_checks")
+	if got := get.Query.Get("project_id"); got != "proj-uuid" {
+		t.Errorf("project_id = %q, want the resolved UUID proj-uuid", got)
+	}
+}
+
+func TestPFCApply_OrganizationScopePatchesFullSpec(t *testing.T) {
+	reqs, _, _ := pfcMock(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 200, map[string]any{"commands": []string{"checkout"}})
+	})
+
+	pfcApply.commands = []string{"checkout", "make security-scan"}
+	pfcApply.secrets = []string{"scanner-token"}
+	if err := pfcApplyCmd.RunE(pfcApplyCmd, nil); err != nil {
+		t.Fatalf("pfc apply: %v", err)
+	}
+
+	patch := find(t, reqs, "PATCH", "/api/v1alpha/pre_flight_checks")
+	if got := asStrings(patch.Body["commands"]); len(got) != 2 || got[0] != "checkout" {
+		t.Errorf("commands = %v, want [checkout, make security-scan]", got)
+	}
+	if got := asStrings(patch.Body["secrets"]); len(got) != 1 || got[0] != "scanner-token" {
+		t.Errorf("secrets = %v, want [scanner-token]", got)
+	}
+	if _, sent := patch.Body["project_id"]; sent {
+		t.Errorf("project_id = %v, want it absent for organization scope", patch.Body["project_id"])
+	}
+	if _, sent := patch.Body["agent"]; sent {
+		t.Errorf("agent = %v, want it absent when no agent flags are given", patch.Body["agent"])
+	}
+}
+
+func TestPFCApply_ProjectScopeSendsProjectIDAndAgentInBody(t *testing.T) {
+	reqs, _, _ := pfcMock(t, projectLookupHandler(t, "my-project", "proj-uuid",
+		func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{"commands": []string{"./gate.sh"}})
+		}))
+
+	pfcApply.project = "my-project"
+	pfcApply.commands = []string{"./gate.sh"}
+	pfcApply.machineType = "e2-standard-2"
+	pfcApply.osImage = "ubuntu2204"
+	if err := pfcApplyCmd.RunE(pfcApplyCmd, nil); err != nil {
+		t.Fatalf("pfc apply: %v", err)
+	}
+
+	patch := find(t, reqs, "PATCH", "/api/v1alpha/pre_flight_checks")
+	if patch.Body["project_id"] != "proj-uuid" {
+		t.Errorf("project_id = %v, want proj-uuid", patch.Body["project_id"])
+	}
+	agent, ok := patch.Body["agent"].(map[string]any)
+	if !ok {
+		t.Fatalf("agent = %v, want an object", patch.Body["agent"])
+	}
+	if agent["machine_type"] != "e2-standard-2" || agent["os_image"] != "ubuntu2204" {
+		t.Errorf("agent = %v, want e2-standard-2/ubuntu2204", agent)
+	}
+	if got := asStrings(patch.Body["secrets"]); got == nil || len(got) != 0 {
+		t.Errorf("secrets = %v, want an empty array so apply clears bound secrets", patch.Body["secrets"])
+	}
+}
+
+func TestPFCApply_FromFileIsSentAsTheBody(t *testing.T) {
+	path := writeSpecFile(t, "pfc.yml", `commands:
+  - checkout
+  - ./scripts/gate.sh
+secrets:
+  - gate-token
+`)
+	reqs, _, _ := pfcMock(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 200, map[string]any{"commands": []string{"checkout"}})
+	})
+
+	pfcApply.fromFile = path
+	if err := pfcApplyCmd.RunE(pfcApplyCmd, nil); err != nil {
+		t.Fatalf("pfc apply: %v", err)
+	}
+
+	patch := find(t, reqs, "PATCH", "/api/v1alpha/pre_flight_checks")
+	if got := asStrings(patch.Body["commands"]); len(got) != 2 || got[1] != "./scripts/gate.sh" {
+		t.Errorf("commands = %v, want the two commands from the file", got)
+	}
+	if got := asStrings(patch.Body["secrets"]); len(got) != 1 || got[0] != "gate-token" {
+		t.Errorf("secrets = %v, want [gate-token]", got)
+	}
+}
+
+func TestPFCApply_ConflictingInputNeverReachesTheAPI(t *testing.T) {
+	path := writeSpecFile(t, "pfc.yml", "commands:\n  - checkout\n")
+	reqs, _, stderr := pfcMock(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 200, map[string]any{})
+	})
+
+	pfcApply.fromFile = path
+	pfcApply.commands = []string{"./gate.sh"}
+	if err := pfcApplyCmd.RunE(pfcApplyCmd, nil); err == nil {
+		t.Fatal("expected pfc apply to fail when both input modes are used")
+	}
+
+	if n := count(reqs, "PATCH", "/api/v1alpha/pre_flight_checks"); n != 0 {
+		t.Errorf("%d PATCH requests, want 0 — bad input must not reach the API", n)
+	}
+	if got := decodeError(t, stderr)["code"]; got != "flag_error" {
+		t.Errorf("error code = %v, want flag_error", got)
+	}
+}
+
+func TestPFCDelete_OrganizationAndProjectScope(t *testing.T) {
+	t.Run("organization", func(t *testing.T) {
+		reqs, stdout, _ := pfcMock(t, func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 200, map[string]any{})
+		})
+
+		if err := pfcDeleteCmd.RunE(pfcDeleteCmd, nil); err != nil {
+			t.Fatalf("pfc delete: %v", err)
+		}
+
+		del := find(t, reqs, "DELETE", "/api/v1alpha/pre_flight_checks")
+		if len(del.Query) != 0 {
+			t.Errorf("query = %v, want none for organization scope", del.Query)
+		}
+		if !strings.Contains(stdout.String(), `"organization"`) {
+			t.Errorf("stdout = %q, want it to name the scope deleted", stdout.String())
+		}
+	})
+
+	t.Run("project", func(t *testing.T) {
+		reqs, stdout, _ := pfcMock(t, projectLookupHandler(t, "my-project", "proj-uuid",
+			func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, 200, map[string]any{})
+			}))
+
+		pfcDeleteProjectFlag = "my-project"
+		if err := pfcDeleteCmd.RunE(pfcDeleteCmd, nil); err != nil {
+			t.Fatalf("pfc delete: %v", err)
+		}
+
+		del := find(t, reqs, "DELETE", "/api/v1alpha/pre_flight_checks")
+		if got := del.Query.Get("project_id"); got != "proj-uuid" {
+			t.Errorf("project_id = %q, want proj-uuid", got)
+		}
+		if !strings.Contains(stdout.String(), "proj-uuid") {
+			t.Errorf("stdout = %q, want it to name the project deleted", stdout.String())
+		}
+	})
+}
+
+// ---- error mapping ----------------------------------------------------------
+
+func TestPFCErrorMessage(t *testing.T) {
+	org := pfcScope{}
+	project := pfcScope{projectID: "proj-uuid"}
+
+	tests := []struct {
+		name   string
+		resp   *client.Response
+		scope  pfcScope
+		action string
+		want   string
+	}{
+		{
+			name:   "404 organization",
+			resp:   &client.Response{StatusCode: 404, Body: []byte(`{"message":"Not Found"}`)},
+			scope:  org,
+			action: "view",
+			want:   "no pre-flight check configured for this organization",
+		},
+		{
+			name:   "404 project",
+			resp:   &client.Response{StatusCode: 404, Body: []byte(``)},
+			scope:  project,
+			action: "view",
+			want:   "no pre-flight check configured for this project",
+		},
+		{
+			name:   "401 names the organization manage permission",
+			resp:   &client.Response{StatusCode: 401, Body: []byte(`{"message":"Unauthorized"}`)},
+			scope:  org,
+			action: "manage",
+			want:   "permission denied: this requires the organization.pre_flight_checks.manage permission",
+		},
+		{
+			name:   "401 names the project manage permission",
+			resp:   &client.Response{StatusCode: 401, Body: []byte(`{}`)},
+			scope:  project,
+			action: "manage",
+			want:   "permission denied: this requires the project.pre_flight_checks.manage permission",
+		},
+		{
+			name:   "422 quotes the server's complaint",
+			resp:   &client.Response{StatusCode: 422, Body: []byte(`{"message":"commands cannot be empty"}`)},
+			scope:  org,
+			action: "manage",
+			want:   "invalid pre-flight check: commands cannot be empty",
+		},
+		{
+			name:   "feature disabled is passed through verbatim",
+			resp:   &client.Response{StatusCode: 404, Body: []byte(`{"message":"pre_flight_checks feature is not enabled for your organization"}`)},
+			scope:  org,
+			action: "view",
+			want:   "pre_flight_checks feature is not enabled for your organization",
+		},
+		{
+			name:   "unmapped status falls back to the raw response",
+			resp:   &client.Response{StatusCode: 418, Body: []byte(`teapot`)},
+			scope:  org,
+			action: "view",
+			want:   "HTTP 418: teapot",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pfcErrorMessage(tc.resp, tc.scope, tc.action); got != tc.want {
+				t.Errorf("message = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPFCShow_NotConfiguredReportsAnActionableError(t *testing.T) {
+	_, _, stderr := pfcMock(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 404, map[string]any{"message": "Not Found"})
+	})
+
+	if err := pfcShowCmd.RunE(pfcShowCmd, nil); err == nil {
+		t.Fatal("expected pfc show to fail on 404")
+	}
+
+	e := decodeError(t, stderr)
+	if e["code"] != "api_error" {
+		t.Errorf("code = %v, want api_error", e["code"])
+	}
+	if e["message"] != "no pre-flight check configured for this organization" {
+		t.Errorf("message = %v, want the not-configured wording", e["message"])
+	}
+	if e["status"] != float64(404) {
+		t.Errorf("status = %v, want 404", e["status"])
+	}
+}
+
+func TestPFCApply_PermissionDeniedNamesThePermission(t *testing.T) {
+	_, _, stderr := pfcMock(t, projectLookupHandler(t, "my-project", "proj-uuid",
+		func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, 401, map[string]any{"message": "Unauthorized"})
+		}))
+
+	pfcApply.project = "my-project"
+	pfcApply.commands = []string{"./gate.sh"}
+	if err := pfcApplyCmd.RunE(pfcApplyCmd, nil); err == nil {
+		t.Fatal("expected pfc apply to fail on 401")
+	}
+
+	msg, _ := decodeError(t, stderr)["message"].(string)
+	if !strings.Contains(msg, "project.pre_flight_checks.manage") {
+		t.Errorf("message = %q, want it to name the manage permission", msg)
+	}
+}
+
+func TestPFCApply_FeatureDisabledIsSurfacedVerbatim(t *testing.T) {
+	const serverMsg = "pre_flight_checks feature is not enabled for your organization"
+	_, _, stderr := pfcMock(t, func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, 404, map[string]any{"message": serverMsg})
+	})
+
+	pfcApply.commands = []string{"./gate.sh"}
+	if err := pfcApplyCmd.RunE(pfcApplyCmd, nil); err == nil {
+		t.Fatal("expected pfc apply to fail when the feature is disabled")
+	}
+
+	if got := decodeError(t, stderr)["message"]; got != serverMsg {
+		t.Errorf("message = %v, want the server's own wording %q", got, serverMsg)
+	}
+}
+
+// ---- MCP: the cobra tree walk picks these up without registration code ------
+
+func TestPFCCommandsRegisterAsMCPTools(t *testing.T) {
+	s := server.NewMCPServer("sem-ai", "test")
+	registerCobraTools(s, rootCmd, "")
+
+	tools := s.ListTools()
+	for _, name := range []string{"pfc_show", "pfc_apply", "pfc_delete"} {
+		tool, ok := tools[name]
+		if !ok {
+			t.Fatalf("tool %q not registered; got %d tools", name, len(tools))
+		}
+		if tool.Tool.Description == "" {
+			t.Errorf("tool %q has no description for the calling agent", name)
+		}
+		if _, ok := tool.Tool.InputSchema.Properties["project"]; !ok {
+			t.Errorf("tool %q has no project parameter", name)
+		}
+	}
+
+	if _, ok := tools["pfc"]; ok {
+		t.Error("the pfc group itself should not be a tool, only its leaves")
+	}
+
+	apply := tools["pfc_apply"]
+	for _, param := range []string{"command", "secret", "machine-type", "os-image", "from-file"} {
+		if _, ok := apply.Tool.InputSchema.Properties[param]; !ok {
+			t.Errorf("pfc_apply is missing the %q parameter", param)
+		}
+	}
+	if !strings.Contains(apply.Tool.Description, "before every workflow") {
+		t.Errorf("pfc_apply description = %q, want it to state what applying changes", apply.Tool.Description)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -136,7 +136,17 @@ func (c *Client) List(kind string) (*Response, error) {
 
 // ListWithParams fetches with query params, returns headers for pagination.
 func (c *Client) ListWithParams(kind string, params url.Values) (*Response, error) {
-	return c.doWithRetry("GET", c.apiURL(fmt.Sprintf("%s?%s", kind, params.Encode())), nil)
+	return c.doWithRetry("GET", c.apiURL(pathWithParams(kind, params)), nil)
+}
+
+// pathWithParams appends an encoded query string to a path, leaving the path
+// untouched when there are no params (so a scope-less collection call does not
+// end in a bare "?").
+func pathWithParams(path string, params url.Values) string {
+	if len(params) == 0 {
+		return path
+	}
+	return fmt.Sprintf("%s?%s", path, params.Encode())
 }
 
 // ListAll auto-paginates using link header (rel="next") or x-has-more.
@@ -229,6 +239,12 @@ func (c *Client) Patch(kind, id string, body []byte) (*Response, error) {
 	return c.doWithRetry("PATCH", c.apiURL(fmt.Sprintf("%s/%s", kind, id)), body)
 }
 
+// PatchWithParams sends a PATCH request to a collection path (no resource id),
+// with optional query parameters.
+func (c *Client) PatchWithParams(kind string, params url.Values, body []byte) (*Response, error) {
+	return c.doWithRetry("PATCH", c.apiURL(pathWithParams(kind, params)), body)
+}
+
 // Delete sends a DELETE request.
 func (c *Client) Delete(kind, id string) (*Response, error) {
 	return c.doWithRetry("DELETE", c.apiURL(fmt.Sprintf("%s/%s", kind, id)), nil)
@@ -237,6 +253,12 @@ func (c *Client) Delete(kind, id string) (*Response, error) {
 // DeletePath sends a DELETE request to a custom path under /api/{version}/.
 func (c *Client) DeletePath(path string) (*Response, error) {
 	return c.doWithRetry("DELETE", c.apiURL(path), nil)
+}
+
+// DeletePathWithParams sends a DELETE request to a collection path (no resource
+// id), with optional query parameters.
+func (c *Client) DeletePathWithParams(path string, params url.Values) (*Response, error) {
+	return c.doWithRetry("DELETE", c.apiURL(pathWithParams(path, params)), nil)
 }
 
 // DeleteWithParams sends a DELETE request with query parameters.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -690,3 +690,114 @@ func TestPostYAMLEndpointURL(t *testing.T) {
 		t.Errorf("path = %q, want %q", gotPath, wantPath)
 	}
 }
+
+// ---- collection-scoped PATCH / DELETE with query params ---------------------
+
+func TestPatchWithParamsURLAndBody(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	c := newTestClient(host, "tok")
+
+	params := url.Values{"project_id": {"proj-abc"}}
+	_, err := c.PatchWithParams("pre_flight_checks", params, []byte(`{"commands":["make lint"]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != "PATCH" {
+		t.Errorf("method = %q, want PATCH", gotMethod)
+	}
+	if gotPath != "/api/v1alpha/pre_flight_checks" {
+		t.Errorf("path = %q, want /api/v1alpha/pre_flight_checks", gotPath)
+	}
+	if gotQuery != "project_id=proj-abc" {
+		t.Errorf("query = %q, want project_id=proj-abc", gotQuery)
+	}
+	if string(gotBody) != `{"commands":["make lint"]}` {
+		t.Errorf("body = %q, want the JSON spec", string(gotBody))
+	}
+}
+
+func TestPatchWithParamsNoParamsLeavesQueryEmpty(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	c := newTestClient(host, "tok")
+
+	_, err := c.PatchWithParams("pre_flight_checks", nil, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotPath != "/api/v1alpha/pre_flight_checks" {
+		t.Errorf("path = %q, want /api/v1alpha/pre_flight_checks", gotPath)
+	}
+	if gotQuery != "" {
+		t.Errorf("query = %q, want empty", gotQuery)
+	}
+}
+
+func TestDeletePathWithParams(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	c := newTestClient(host, "tok")
+
+	_, err := c.DeletePathWithParams("pre_flight_checks", url.Values{"project_id": {"proj-abc"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != "DELETE" {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/api/v1alpha/pre_flight_checks" {
+		t.Errorf("path = %q, want /api/v1alpha/pre_flight_checks", gotPath)
+	}
+	if gotQuery != "project_id=proj-abc" {
+		t.Errorf("query = %q, want project_id=proj-abc", gotQuery)
+	}
+}
+
+func TestListWithParamsEmptyParamsHasNoTrailingQuestionMark(t *testing.T) {
+	var gotURI string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURI = r.RequestURI
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	c := newTestClient(host, "tok")
+
+	_, err := c.ListWithParams("pre_flight_checks", url.Values{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotURI != "/api/v1alpha/pre_flight_checks" {
+		t.Errorf("request URI = %q, want /api/v1alpha/pre_flight_checks", gotURI)
+	}
+}


### PR DESCRIPTION
Adds a `pfc` command group for reading and changing pre-flight checks — the commands Semaphore runs during pipeline initialization, before any block starts.

Until now sem-ai had no path to them at all. An agent asked to configure a pre-flight check would work out the right change, discover there was no way to apply it, and fall back to asking a human to click through project settings. The `semaphore-promotions` skill even told agents the change could be made "via API", which was not true.

## Commands

```shell
sem-ai pfc show    [--project <name-or-id>]
sem-ai pfc apply   [--project <name-or-id>] --command ... [--secret ...] [--machine-type ...] [--os-image ...]
sem-ai pfc apply   [--project <name-or-id>] --from-file <yaml|json>
sem-ai pfc delete  [--project <name-or-id>]
```

Scope follows `--project`: pass it for a project's check, omit it for the organization-wide one. These land as the MCP tools `pfc_show`, `pfc_apply`, and `pfc_delete` with no extra registration, since the server walks the cobra tree.

## Behaviour worth knowing

Omitting `--project` does **not** fall back to detecting the project from the git remote, unlike most commands here. For an organization-wide change that fallback could silently retarget the write at whichever project the current directory happens to point to.

`apply` replaces the whole check rather than merging into it, and always sends `secrets`, so previously bound secrets can be cleared. A spec with no commands is rejected client-side, which keeps a lone `--machine-type` from wiping the commands. Flags and `--from-file` are mutually exclusive, and the file format is detected by parsing rather than by extension.

Server responses are mapped to something a caller can act on: 404 becomes "no pre-flight check configured for this scope", 401 and 403 name the permission that is missing for the attempted action, and a feature-disabled response is surfaced in the server's own words.

## Also here

- `pkg/client` gains `PatchWithParams` and `DeletePathWithParams` for collection-scoped calls; the existing `Patch(kind, id, …)` would emit a trailing slash against a collection path. Both go through the `apiURL` seam, so they are testable against `httptest`.
- The stale "or via API" claim in the `semaphore-promotions` skill is corrected to point at `sem-ai pfc`.
- A new `semaphore-preflight` skill covers the diagnose-then-configure loop: a pipeline that fails at initialization with no block output is usually a pre-flight check failure, and the fix is now a command rather than a UI visit.

## Testing

`go test ./...` passes across all packages, including 30 new tests for spec parsing, YAML and JSON files, the mutually-exclusive check, scope shaping, and error mapping. `golangci-lint run ./...` reports 0 issues. MCP registration was verified both by unit test and by a live `tools/list` call against the built binary.

This depends on the matching public API v1alpha endpoints, which ship separately — the commands will return 404 until those are deployed.
