### PR TITLE
chore(release): bump plugin manifests to v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "sem-ai",
       "source": "./assets/plugin",
       "description": "Agent-first Semaphore CI/CD client — skills bundle",
-      "version": "0.2.0"
+      "version": "0.3.0"
     }
   ]
 }

--- a/assets/plugin/.codex-plugin/plugin.json
+++ b/assets/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "repository": "https://github.com/semaphoreio/sem-ai",

--- a/assets/plugin/plugin.json
+++ b/assets/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sem-ai",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agent-first Semaphore CI/CD client — skills bundle",
   "homepage": "https://github.com/semaphoreio/sem-ai",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "sem-ai",
   "display_name": "Semaphore CI",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Agent-first Semaphore CI/CD — manage pipelines, tests, deploys, flaky detection.",
   "long_description": "sem-ai exposes the full Semaphore CI/CD loop as MCP tools: inspect pipelines and workflows, read job logs, surface flaky tests and insights, manage secrets and notifications, trigger deploys, and validate YAML. Connect with your organization host and a Semaphore API token.",
   "author": {


### PR DESCRIPTION
Release v0.3.0. Since v0.2.0:

- testbox: `list` subcommand + `stop` now confirms the job actually stops (semaphoreio/sem-ai#74)
- fix(test): fetch unified test report from workflow scope before job fallback (semaphoreio/sem-ai#72)
- fix(diagnose): surface failure_reason for jobs that never ran (semaphoreio/sem-ai#71)
- fix(topology): read block dependencies from local pipeline YAML (semaphoreio/sem-ai#52)
- fix(deps): bump golang.org/x/text to v0.39.0 (CVE-2026-56852) (semaphoreio/sem-ai#75)

After merge: push tag `v0.3.0` to trigger GoReleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)