### PR TITLE
feat(artifact): browse and bulk-pull nested artifact trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,11 @@ All analytics commands accept `--project` (auto-detected from git), `--days`, `-
 
 | Command | Description |
 |---------|-------------|
-| `artifact list --scope jobs --id <id>` | List artifacts |
+| `artifact list --scope jobs --id <id>` | List artifacts at the top level |
+| `artifact list --scope jobs --id <id> --path <dir>` | List one directory deeper |
+| `artifact list --scope jobs --id <id> --recursive` | Flatten the whole tree to files |
 | `artifact get --scope jobs --id <id> --path <p>` | Download an artifact |
+| `artifact pull --scope workflows --id <id> -o <dir>` | Bulk download a tree to disk |
 
 ### Utility
 

--- a/assets/plugin/skills/manage-infra/SKILL.md
+++ b/assets/plugin/skills/manage-infra/SKILL.md
@@ -50,11 +50,40 @@ sem-ai task create <name> --branch main --file <path> [--cron "<expr>"] \
 ```
 
 ## Artifacts
+
+An artifact store is a tree. A bare `list` shows only its top level, where
+entries with `"is_directory": true` are directories — feed their `path` back
+through `--path` to go one level deeper, or skip the walking with `--recursive`.
+
 ```bash
 sem-ai artifact list --scope jobs --id <job-id>
 sem-ai artifact list --scope workflows --id <wf-id>
+
+# Browse nested paths.
+sem-ai artifact list --scope workflows --id <wf-id> --path test-results
+sem-ai artifact list --scope workflows --id <wf-id> --recursive   # files only
+
 sem-ai artifact get --scope jobs --id <job-id> --path <path> [--output file]
+
+# Bulk download. Mirrors the remote tree under --output-dir (default
+# ./artifacts-<id>, never the working directory), skips files already there
+# unless --force, and --dry-run lists without writing.
+sem-ai artifact pull --scope workflows --id <wf-id> --output-dir ./artifacts
+sem-ai artifact pull --scope workflows --id <wf-id> --path test-results -o ./tr
 ```
+
+`list --recursive`, `pull` and `pull --dry-run` share one rule: if the walk
+could not see the whole tree — a directory failed to list, or it stopped at
+the 1000-listing cap — the command reports what it found on stdout and then
+exits **non-zero** and sets `"complete": false` in the payload. Key off
+`complete` — it is the one signal all three share; `status` additionally
+distinguishes `pulled_partial` from `dry_run_partial` for humans. Details come
+in `errors` and, for a capped walk, `truncated` + `unvisited_directories`. The
+files it did find are still written. Retrying does not recover missing
+directories; narrow with `--path`.
+
+`get` needs a file path: pointed at a directory it fails with
+`"code": "is_directory"` and names the two commands that do work on one.
 
 ## Pipeline YAML
 ```bash

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -4,11 +4,19 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
+	"math/rand/v2"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/semaphoreio/sem-ai/pkg/client"
 	"github.com/semaphoreio/sem-ai/pkg/config"
@@ -21,16 +29,411 @@ var artifactCmd = &cobra.Command{
 	Short: "Artifact operations: list and download build artifacts",
 }
 
+const (
+	// defaultMaxWalkRequests bounds the directory listings one walk may issue.
+	// The artifacts API enforces a per-organization request budget over a
+	// short window, shared by every consumer in that organization, so one
+	// command should not be able to spend most of it — and `pull` spends a
+	// signed-URL request per file on top of its listings. Raise it with
+	// SEM_AI_MAX_ARTIFACT_LISTINGS for a store that genuinely needs more.
+	//
+	// It is not a cost control — artifact billing meters storage and egress,
+	// never request counts. The operations are absorbed server-side.
+	defaultMaxWalkRequests = 500
+	envMaxWalkRequests     = "SEM_AI_MAX_ARTIFACT_LISTINGS"
+
+	pullConcurrency = 8
+
+	// pullTempPrefix names the in-progress files writeFileAtomic renames from.
+	// Tests assert on it, so it lives here rather than inline.
+	pullTempPrefix = ".sem-ai-pull-"
+)
+
+// walkRequestCap returns the listing budget for one walk. A project-scope
+// store can legitimately exceed the default, so it is overridable; a value
+// that is not a positive integer is reported and ignored rather than silently
+// turning into a cap of zero.
+func walkRequestCap() int {
+	raw := strings.TrimSpace(os.Getenv(envMaxWalkRequests))
+	if raw == "" {
+		return defaultMaxWalkRequests
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		output.Warn(fmt.Sprintf("%s=%q is not a positive integer; using the default of %d",
+			envMaxWalkRequests, raw, defaultMaxWalkRequests))
+		return defaultMaxWalkRequests
+	}
+	return n
+}
+
+// apiError carries the HTTP status alongside the message so callers can tell
+// a missing path from a permission gate. Most of cmd/ passes the real status
+// to output.Error; the artifact commands do the same through this.
+type apiError struct {
+	Status int
+	Body   string
+}
+
+func (e *apiError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("HTTP %d", e.Status)
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.Status, e.Body)
+}
+
+func statusOf(err error) int {
+	var apiErr *apiError
+	if errors.As(err, &apiErr) {
+		return apiErr.Status
+	}
+	// Retries exhausted inside the client: the status survives on its error
+	// type, and losing it here would turn a rate limit into a generic
+	// failure the walk then treats as one bad directory.
+	var httpErr *client.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode
+	}
+	return 0
+}
+
+// orgWideRefusal reports whether a status describes a refusal that applies to
+// the whole organization rather than to one path, and so cannot be improved by
+// asking about a different directory.
+func orgWideRefusal(status int) bool {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	}
+	return false
+}
+
+// artifactsAPIDisabled reports whether err is the v1alpha gate refusing the
+// artifacts API for this organization. The gate requires BOTH the `artifacts`
+// and `artifacts_api` features; some plans enable the first and not the
+// second, so "artifacts work in the UI" is not evidence that this will.
+func artifactsAPIDisabled(err error) bool {
+	if statusOf(err) != http.StatusForbidden {
+		return false
+	}
+	var body string
+	var apiErr *apiError
+	var httpErr *client.HTTPError
+	switch {
+	case errors.As(err, &apiErr):
+		body = apiErr.Body
+	case errors.As(err, &httpErr):
+		body = httpErr.Body
+	}
+	return strings.Contains(strings.ToLower(body), "artifacts api feature is not enabled")
+}
+
+// reportArtifactError names the failure the user actually hit. A feature gate
+// reported as a generic api_error sends people debugging their scope ID.
+func reportArtifactError(err error) {
+	if statusOf(err) == http.StatusTooManyRequests {
+		wait := "a few minutes"
+		var httpErr *client.HTTPError
+		if errors.As(err, &httpErr) && httpErr.RetryAfter > 0 {
+			wait = httpErr.RetryAfter.String()
+		}
+		output.Error("rate_limited",
+			fmt.Sprintf("the artifacts API rate limit for this organization was exceeded. The budget is per organization and windowed, so it is shared with everything else in the org and retrying immediately makes it worse — wait %s, or narrow the request with --path", wait),
+			http.StatusTooManyRequests)
+		return
+	}
+	if artifactsAPIDisabled(err) {
+		output.Error("feature_disabled",
+			"the artifacts API is not enabled for this organization: both the `artifacts` and `artifacts_api` features are required, and a plan may enable one without the other. Contact support to enable it",
+			http.StatusForbidden)
+		return
+	}
+	status := statusOf(err)
+	if status == 0 {
+		status = 1
+	}
+	output.Error("api_error", err.Error(), status)
+}
+
+type artifactEntry struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	IsDirectory bool   `json:"is_directory"`
+	// Size is a pointer because the API omits it for directories and only for
+	// directories: absence is how a directory is marked. A plain int64 with
+	// omitempty erased "size": 0 for genuinely empty artifacts, making an
+	// empty file indistinguishable from a directory on the way back out.
+	Size *int64 `json:"size,omitempty"`
+}
+
+func listArtifactPath(c *client.Client, scope, scopeID, path string) ([]artifactEntry, error) {
+	params := url.Values{}
+	params.Set("scope", scope)
+	params.Set("scope_id", scopeID)
+	if path != "" {
+		params.Set("path", path)
+	}
+
+	resp, err := c.ListWithParams("artifacts", params)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, &apiError{Status: resp.StatusCode, Body: string(resp.Body)}
+	}
+
+	var parsed struct {
+		Artifacts []artifactEntry `json:"artifacts"`
+	}
+	if err := json.Unmarshal(resp.Body, &parsed); err != nil {
+		return nil, err
+	}
+	return parsed.Artifacts, nil
+}
+
+type walkError struct {
+	Path  string `json:"path"`
+	Error string `json:"error"`
+}
+
+type walkResult struct {
+	Files     []artifactEntry
+	Truncated bool
+	// Unvisited counts directories still queued when the cap was hit. It is a
+	// floor, not a total: each of those may hold more below it.
+	Unvisited int
+	// Cap is the listing budget this walk ran under, so the message a caller
+	// prints matches the limit actually applied.
+	Cap    int
+	Errors []walkError
+}
+
+// Incomplete reports whether the walk failed to see the whole tree.
+func (w walkResult) Incomplete() bool { return w.Truncated || len(w.Errors) > 0 }
+
+// problems describes each reason the walk fell short, for the error a caller
+// returns. A partial result that exits zero cannot be told apart from a
+// complete one, so every caller of walkArtifacts reports these.
+func (w walkResult) problems() []string {
+	var out []string
+	if n := len(w.Errors); n > 0 {
+		out = append(out, fmt.Sprintf("%d director%s could not be listed (likely removed by retention)",
+			n, map[bool]string{true: "y", false: "ies"}[n == 1]))
+	}
+	if w.Truncated {
+		out = append(out, fmt.Sprintf("the walk stopped at the %d-listing cap with at least %d director%s unvisited (raise %s if the store is genuinely this large)",
+			w.Cap, w.Unvisited, map[bool]string{true: "y", false: "ies"}[w.Unvisited == 1], envMaxWalkRequests))
+	}
+	return out
+}
+
+// walkArtifacts expands the tree under root breadth-first. A failure listing
+// the root is fatal — nothing was found and the scope is likely wrong. A
+// failure deeper in is recorded and the walk continues: retention deletes
+// subtrees mid-walk, and losing every file found so far to one expired
+// directory is worse than reporting the gap.
+func walkArtifacts(c *client.Client, scope, scopeID, root string) (walkResult, error) {
+	var res walkResult
+
+	// The root is listed outside the loop so that "the root failed" is a
+	// property of the call rather than of a loop counter, which a later
+	// `continue` could silently turn into a recoverable error.
+	rootEntries, err := listArtifactPath(c, scope, scopeID, root)
+	if err != nil {
+		return walkResult{}, err
+	}
+
+	res.Cap = walkRequestCap()
+	seen := map[string]bool{root: true}
+	var queue []string
+	requests := 1
+
+	collect := func(entries []artifactEntry) {
+		for _, e := range entries {
+			if !e.IsDirectory {
+				res.Files = append(res.Files, e)
+				continue
+			}
+			// A store that reports a directory already walked would
+			// otherwise loop until the request cap, re-emitting its files
+			// on every pass.
+			if seen[e.Path] {
+				continue
+			}
+			seen[e.Path] = true
+			queue = append(queue, e.Path)
+		}
+	}
+	collect(rootEntries)
+
+	for len(queue) > 0 {
+		if requests >= res.Cap {
+			res.Truncated = true
+			res.Unvisited = len(queue)
+			break
+		}
+
+		dir := queue[0]
+		queue = queue[1:]
+
+		entries, err := listArtifactPath(c, scope, scopeID, dir)
+		requests++
+		if err != nil {
+			// 401, 403 and 429 apply to the organization, not to this
+			// directory: every remaining listing would answer the same way,
+			// so continuing multiplies one refusal into hundreds. A 429 is
+			// worse than the others — the budget is windowed, so the extra
+			// requests push the window out and delay recovery. Anything else
+			// is per-directory (a subtree removed by retention) or transient,
+			// and losing the whole walk to it is the bug this tolerates.
+			if orgWideRefusal(statusOf(err)) {
+				return walkResult{}, err
+			}
+			res.Errors = append(res.Errors, walkError{Path: dir, Error: err.Error()})
+			continue
+		}
+		collect(entries)
+	}
+
+	sort.Slice(res.Files, func(a, b int) bool { return res.Files[a].Path < res.Files[b].Path })
+	return res, nil
+}
+
+// incompleteWalk turns an incomplete walk into the error its command returns,
+// so a caller that saw only part of the tree never exits zero.
+func incompleteWalk(walk walkResult, what string) error {
+	if !walk.Incomplete() {
+		return nil
+	}
+	return fmt.Errorf("incomplete %s: %s. Retrying will not recover the missing directories — narrow it with --path",
+		what, strings.Join(walk.problems(), "; "))
+}
+
+func safeRelativePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("empty path")
+	}
+	if strings.HasPrefix(path, "/") || strings.Contains(path, "\\") {
+		return "", fmt.Errorf("unsafe path %q", path)
+	}
+	segments := strings.Split(path, "/")
+	for _, seg := range segments {
+		// Windows strips trailing dots and spaces from path components, so
+		// ".. " and "..." both reach the filesystem as "..". Each segment is
+		// judged by what the OS would make of it, not by its literal text —
+		// a purely lexical check (filepath.Rel, filepath.IsLocal) sees ".. "
+		// as an ordinary name and misses the escape.
+		if t := strings.TrimRight(seg, ". "); t == "" || t == "." || t == ".." {
+			return "", fmt.Errorf("unsafe path %q", path)
+		}
+	}
+
+	rel := filepath.Join(segments...)
+	// IsLocal adds the platform's own rules on top: drive-relative paths
+	// like "C:x" and reserved device names such as NUL or CON.
+	if !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("unsafe path %q", path)
+	}
+	return rel, nil
+}
+
+// containedIn reports whether dest lands inside root. The segment rules in
+// safeRelativePath should make this unreachable; it is kept as a second
+// barrier because the cost of being wrong here is writing outside the
+// directory the user named.
+func containedIn(root, dest string) bool {
+	rel, err := filepath.Rel(root, dest)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func gunzip(data []byte) ([]byte, error) {
+	if len(data) < 2 || data[0] != 0x1f || data[1] != 0x8b {
+		return data, nil
+	}
+	r, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("gzip: %w", err)
+	}
+	defer r.Close()
+	decompressed, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("gzip: %w", err)
+	}
+	return decompressed, nil
+}
+
+// gzipNameSuffixes are the path endings that already advertise gzip
+// compression, so their bytes are written to disk untouched.
+var gzipNameSuffixes = []string{".gz", ".gzip", ".tgz", ".svgz"}
+
+func pathAdvertisesGzip(p string) bool {
+	lower := strings.ToLower(p)
+	for _, suffix := range gzipNameSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func downloadArtifact(c *client.Client, scope, scopeID, path string) ([]byte, error) {
+	params := url.Values{}
+	params.Set("scope", scope)
+	params.Set("scope_id", scopeID)
+	params.Set("path", path)
+	params.Set("method", "GET")
+
+	resp, err := c.ListWithParams("artifacts/signed_url", params)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, &apiError{Status: resp.StatusCode, Body: string(resp.Body)}
+	}
+
+	var signedResp struct {
+		Items []struct {
+			Path string `json:"path"`
+			URL  string `json:"url"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(resp.Body, &signedResp); err != nil || len(signedResp.Items) == 0 {
+		return nil, fmt.Errorf("artifact not found")
+	}
+
+	dlResp, err := c.GetExternal(signedResp.Items[0].URL)
+	if err != nil {
+		return nil, err
+	}
+	if dlResp.StatusCode != 200 {
+		return nil, &apiError{Status: dlResp.StatusCode}
+	}
+	return dlResp.Body, nil
+}
+
 var (
-	artifactScope   string
-	artifactScopeID string
+	artifactScope     string
+	artifactScopeID   string
+	artifactListPath  string
+	artifactRecursive bool
 )
 
 var artifactListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List artifacts for a job, workflow, or project",
+	Long: `List artifacts for a job, workflow, or project.
+
+Without --path, lists the top level of the artifact store. Entries with
+"is_directory": true are directories — pass their "path" back via --path to
+list one level deeper, or use --recursive to expand the whole tree at once.
+--recursive returns files only; directories are implied by the file paths.`,
 	Example: `  sem-ai artifact list --scope jobs --id <job-id>
   sem-ai artifact list --scope workflows --id <workflow-id>
+  sem-ai artifact list --scope workflows --id <workflow-id> --path test-results
+  sem-ai artifact list --scope workflows --id <workflow-id> --recursive
   sem-ai artifact list --scope projects --id <project-id>`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !config.IsConfigured() {
@@ -42,26 +445,35 @@ var artifactListCmd = &cobra.Command{
 		}
 
 		c := client.New()
-		params := url.Values{}
-		params.Set("scope", artifactScope)
-		params.Set("scope_id", artifactScopeID)
 
-		resp, err := c.ListWithParams("artifacts", params)
+		if artifactRecursive {
+			walk, err := walkArtifacts(c, artifactScope, artifactScopeID, artifactListPath)
+			if err != nil {
+				reportArtifactError(err)
+				return err
+			}
+			result := map[string]any{"artifacts": walk.Files, "count": len(walk.Files)}
+			if walk.Truncated {
+				result["truncated"] = true
+				result["unvisited_directories"] = walk.Unvisited
+			}
+			if len(walk.Errors) > 0 {
+				result["errors"] = walk.Errors
+			}
+			if walk.Incomplete() {
+				result["complete"] = false
+				result["message"] = strings.Join(walk.problems(), "; ")
+			}
+			output.Result(result)
+			return incompleteWalk(walk, "listing")
+		}
+
+		entries, err := listArtifactPath(c, artifactScope, artifactScopeID, artifactListPath)
 		if err != nil {
-			output.Error("api_error", err.Error(), 1)
+			reportArtifactError(err)
 			return err
 		}
-		if resp.StatusCode != 200 {
-			output.Error("api_error", fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body)), resp.StatusCode)
-			return fmt.Errorf("API returned %d", resp.StatusCode)
-		}
-
-		var result any
-		if err := json.Unmarshal(resp.Body, &result); err != nil {
-			output.Error("parse_error", err.Error(), 1)
-			return err
-		}
-		output.Result(result)
+		output.Result(map[string]any{"artifacts": entries})
 		return nil
 	},
 }
@@ -89,60 +501,40 @@ var artifactGetCmd = &cobra.Command{
 
 		c := client.New()
 
-		// Get signed URL
-		params := url.Values{}
-		params.Set("scope", artifactGetScope)
-		params.Set("scope_id", artifactGetScopeID)
-		params.Set("path", artifactGetPath)
-		params.Set("method", "GET")
-
-		resp, err := c.ListWithParams("artifacts/signed_url", params)
+		data, err := downloadArtifact(c, artifactGetScope, artifactGetScopeID, artifactGetPath)
 		if err != nil {
-			output.Error("api_error", err.Error(), 1)
+			// Checked before the directory probe: that probe hits the same
+			// gate and would just spend a second request to learn nothing.
+			if artifactsAPIDisabled(err) {
+				reportArtifactError(err)
+				return err
+			}
+			if entries, listErr := listArtifactPath(c, artifactGetScope, artifactGetScopeID, artifactGetPath); listErr == nil && len(entries) > 0 {
+				msg := fmt.Sprintf("%q is a directory (%d entries); use 'artifact list --path %s' to browse it or 'artifact pull --path %s' to download it",
+					artifactGetPath, len(entries), artifactGetPath, artifactGetPath)
+				output.Error("is_directory", msg, 400)
+				return fmt.Errorf("%s", msg)
+			}
+			status := statusOf(err)
+			if status == 0 {
+				status = 1
+			}
+			output.Error("download_error", err.Error(), status)
 			return err
 		}
-		if resp.StatusCode != 200 {
-			output.Error("api_error", fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body)), resp.StatusCode)
-			return fmt.Errorf("API returned %d", resp.StatusCode)
-		}
 
-		var signedResp struct {
-			Items []struct {
-				Path string `json:"path"`
-				URL  string `json:"url"`
-			} `json:"items"`
-		}
-		if err := json.Unmarshal(resp.Body, &signedResp); err != nil || len(signedResp.Items) == 0 {
-			output.Error("not_found", "artifact not found", 404)
-			return fmt.Errorf("artifact not found")
-		}
-
-		// Download
-		dlResp, err := c.GetExternal(signedResp.Items[0].URL)
-		if err != nil {
-			output.Error("download_error", err.Error(), 1)
-			return err
-		}
-		if dlResp.StatusCode != 200 {
-			output.Error("download_error", fmt.Sprintf("HTTP %d", dlResp.StatusCode), dlResp.StatusCode)
-			return fmt.Errorf("download failed: HTTP %d", dlResp.StatusCode)
-		}
-
-		data := dlResp.Body
-
-		// Auto-decompress gzip
-		if len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b {
-			r, err := gzip.NewReader(bytes.NewReader(data))
-			if err == nil {
-				decompressed, err := io.ReadAll(r)
-				r.Close()
-				if err == nil {
-					data = decompressed
-				}
+		// A file on disk must not contradict its own name, so an --output
+		// path advertising gzip keeps the bytes as they arrived. Streaming to
+		// stdout has no name to contradict and is meant to be read, so it
+		// always inflates.
+		if artifactGetOutput == "" || !pathAdvertisesGzip(artifactGetOutput) {
+			data, err = gunzip(data)
+			if err != nil {
+				output.Error("decompress_error", fmt.Sprintf("%s: %s", artifactGetPath, err), 1)
+				return err
 			}
 		}
 
-		// Write to file or stdout
 		if artifactGetOutput != "" {
 			dir := filepath.Dir(artifactGetOutput)
 			if dir != "." {
@@ -159,23 +551,290 @@ var artifactGetCmd = &cobra.Command{
 				"size":   len(data),
 			})
 		} else {
-			// Output raw content to stdout
 			os.Stdout.Write(data)
 		}
 		return nil
 	},
 }
 
+var (
+	artifactPullScope     string
+	artifactPullScopeID   string
+	artifactPullPath      string
+	artifactPullOutputDir string
+	artifactPullForce     bool
+	artifactPullDryRun    bool
+)
+
+type pullResult struct {
+	Path   string `json:"path"`
+	Output string `json:"output,omitempty"`
+	Size   int64  `json:"size"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+var artifactPullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Bulk download every artifact under a path, preserving the directory tree",
+	Long: `Bulk download artifacts for a job, workflow, or project.
+
+Walks the artifact store recursively from --path (the whole store by default)
+and writes every file it finds under --output-dir, mirroring the remote
+directory layout. Existing files are skipped unless --force is passed.
+
+Without --output-dir the tree is written to ./artifacts-<id>, never straight
+into the working directory.
+
+Artifacts stored gzipped but not named with a gzip suffix (.gz, .tgz, .svgz,
+…) are decompressed on write; gzip-named paths are written byte-for-byte.`,
+	Example: `  sem-ai artifact pull --scope workflows --id <workflow-id> --output-dir ./artifacts
+  sem-ai artifact pull --scope workflows --id <workflow-id> --path test-results
+  sem-ai artifact pull --scope jobs --id <job-id> --output-dir ./job --force
+  sem-ai artifact pull --scope workflows --id <workflow-id> --dry-run`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !config.IsConfigured() {
+			return fmt.Errorf("not configured; run 'sem-ai connect' first")
+		}
+		if artifactPullScope == "" || artifactPullScopeID == "" {
+			output.Error("invalid_args", "--scope and --id are required", 1)
+			return fmt.Errorf("--scope and --id are required")
+		}
+
+		if artifactPullOutputDir == "" {
+			artifactPullOutputDir = "artifacts-" + artifactPullScopeID
+		}
+
+		c := client.New()
+
+		walk, err := walkArtifacts(c, artifactPullScope, artifactPullScopeID, artifactPullPath)
+		if err != nil {
+			reportArtifactError(err)
+			return err
+		}
+		files := walk.Files
+
+		if artifactPullDryRun {
+			result := map[string]any{
+				"status":     "dry_run",
+				"output_dir": artifactPullOutputDir,
+				"count":      len(files),
+				"artifacts":  files,
+			}
+			if walk.Truncated {
+				result["truncated"] = true
+				result["unvisited_directories"] = walk.Unvisited
+			}
+			if len(walk.Errors) > 0 {
+				result["errors"] = walk.Errors
+			}
+			if walk.Incomplete() {
+				result["complete"] = false
+				result["status"] = "dry_run_partial"
+				result["message"] = strings.Join(walk.problems(), "; ")
+			}
+			output.Result(result)
+			return incompleteWalk(walk, "dry run")
+		}
+
+		results := pullFiles(c, files)
+
+		var downloaded, skipped, failed int
+		var totalBytes int64
+		for _, r := range results {
+			switch r.Status {
+			case "downloaded":
+				downloaded++
+				totalBytes += r.Size
+			case "skipped":
+				skipped++
+			default:
+				failed++
+			}
+		}
+
+		result := map[string]any{
+			"status":     "pulled",
+			"output_dir": artifactPullOutputDir,
+			"downloaded": downloaded,
+			"skipped":    skipped,
+			"failed":     failed,
+			"bytes":      totalBytes,
+			"artifacts":  results,
+		}
+		if walk.Truncated {
+			result["truncated"] = true
+			result["unvisited_directories"] = walk.Unvisited
+		}
+		if len(walk.Errors) > 0 {
+			result["errors"] = walk.Errors
+		}
+
+		problems := walk.problems()
+		if failed > 0 {
+			problems = append(problems, fmt.Sprintf("%d of %d artifacts failed to download", failed, len(results)))
+		}
+		if len(problems) > 0 {
+			result["complete"] = false
+			result["status"] = "pulled_partial"
+			result["message"] = strings.Join(problems, "; ")
+		}
+		output.Result(result)
+
+		if len(problems) == 0 {
+			return nil
+		}
+
+		msg := fmt.Sprintf("incomplete pull: %s; %d file%s written to %s",
+			strings.Join(problems, "; "), downloaded,
+			map[bool]string{true: "", false: "s"}[downloaded == 1], artifactPullOutputDir)
+		if walk.Incomplete() {
+			// Said plainly so an agent does not loop: the directories are
+			// gone, and asking again returns the same answer.
+			msg += ". Retrying will not recover the missing directories — narrow the pull with --path"
+		}
+		return fmt.Errorf("%s", msg)
+	},
+}
+
+func pullFiles(c *client.Client, files []artifactEntry) []pullResult {
+	results := make([]pullResult, len(files))
+	sem := make(chan struct{}, pullConcurrency)
+	var wg sync.WaitGroup
+
+	for i, f := range files {
+		// Acquired before the goroutine is spawned: acquiring inside would
+		// create one goroutine per file up front and only then throttle
+		// them, which for a large tree is a lot of stacks doing nothing.
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(i int, f artifactEntry) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[i] = pullOne(c, f)
+		}(i, f)
+	}
+	wg.Wait()
+	return results
+}
+
+func pullOne(c *client.Client, f artifactEntry) pullResult {
+	rel, err := safeRelativePath(f.Path)
+	if err != nil {
+		return pullResult{Path: f.Path, Status: "failed", Error: err.Error()}
+	}
+	dest := filepath.Join(artifactPullOutputDir, rel)
+	if !containedIn(artifactPullOutputDir, dest) {
+		return pullResult{Path: f.Path, Status: "failed", Error: fmt.Sprintf("unsafe path %q", f.Path)}
+	}
+
+	if !artifactPullForce {
+		// Lstat, not Stat: a symlink is reported as itself rather than as
+		// whatever it points at. Only a real file already holding this
+		// artifact's bytes is a legitimate skip — a directory or a device at
+		// the destination is a conflict, and calling it "skipped" would exit
+		// zero while nothing local holds the content.
+		if info, statErr := os.Lstat(dest); statErr == nil {
+			if !info.Mode().IsRegular() {
+				return pullResult{
+					Path:   f.Path,
+					Status: "failed",
+					Error:  fmt.Sprintf("%s exists and is not a regular file (%s)", dest, info.Mode().Type()),
+				}
+			}
+			return pullResult{Path: f.Path, Output: dest, Status: "skipped"}
+		}
+	}
+
+	data, err := downloadArtifact(c, artifactPullScope, artifactPullScopeID, f.Path)
+	if err != nil {
+		return pullResult{Path: f.Path, Status: "failed", Error: err.Error()}
+	}
+	if !pathAdvertisesGzip(f.Path) {
+		data, err = gunzip(data)
+		if err != nil {
+			return pullResult{Path: f.Path, Status: "failed", Error: err.Error()}
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return pullResult{Path: f.Path, Status: "failed", Error: err.Error()}
+	}
+	if err := writeFileAtomic(dest, data); err != nil {
+		return pullResult{Path: f.Path, Status: "failed", Error: err.Error()}
+	}
+	return pullResult{Path: f.Path, Output: dest, Size: int64(len(data)), Status: "downloaded"}
+}
+
+// writeFileAtomic writes through a temporary file in the destination
+// directory and renames it into place, so an interrupted pull never leaves a
+// truncated file behind for the next run's skip check to accept as complete.
+//
+// The temporary file is opened rather than taken from os.CreateTemp for two
+// reasons: CreateTemp forces 0600 and would need a Chmod that ignores the
+// caller's umask, and a pattern derived from the artifact name overflows
+// NAME_MAX for long names that a plain write handles fine.
+func writeFileAtomic(dest string, data []byte) error {
+	dir := filepath.Dir(dest)
+
+	var tmp *os.File
+	var tmpName string
+	for attempt := 0; attempt < 100; attempt++ {
+		tmpName = filepath.Join(dir, fmt.Sprintf("%s%d-%d", pullTempPrefix, os.Getpid(), rand.Uint64()))
+		f, err := os.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if err == nil {
+			tmp = f
+			break
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return err
+		}
+	}
+	if tmp == nil {
+		return fmt.Errorf("could not create a temporary file in %s", dir)
+	}
+
+	var renamed bool
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
+}
+
 func init() {
 	artifactListCmd.Flags().StringVar(&artifactScope, "scope", "", "artifact scope: jobs, workflows, or projects")
 	artifactListCmd.Flags().StringVar(&artifactScopeID, "id", "", "scope ID (job/workflow/project UUID)")
+	artifactListCmd.Flags().StringVar(&artifactListPath, "path", "", "directory within the scope to list (default: top level)")
+	artifactListCmd.Flags().BoolVarP(&artifactRecursive, "recursive", "R", false, "expand every subdirectory and return files only")
 
 	artifactGetCmd.Flags().StringVar(&artifactGetScope, "scope", "", "artifact scope: jobs, workflows, or projects")
 	artifactGetCmd.Flags().StringVar(&artifactGetScopeID, "id", "", "scope ID (job/workflow/project UUID)")
 	artifactGetCmd.Flags().StringVar(&artifactGetPath, "path", "", "artifact path within scope")
 	artifactGetCmd.Flags().StringVar(&artifactGetOutput, "output", "", "output file path (default: stdout)")
 
+	artifactPullCmd.Flags().StringVar(&artifactPullScope, "scope", "", "artifact scope: jobs, workflows, or projects")
+	artifactPullCmd.Flags().StringVar(&artifactPullScopeID, "id", "", "scope ID (job/workflow/project UUID)")
+	artifactPullCmd.Flags().StringVar(&artifactPullPath, "path", "", "directory within the scope to pull (default: everything)")
+	artifactPullCmd.Flags().StringVarP(&artifactPullOutputDir, "output-dir", "o", "", "local directory to write artifacts into (default: ./artifacts-<id>)")
+	artifactPullCmd.Flags().BoolVar(&artifactPullForce, "force", false, "overwrite existing local files instead of skipping them")
+	artifactPullCmd.Flags().BoolVar(&artifactPullDryRun, "dry-run", false, "list what would be downloaded without writing files")
+
 	artifactCmd.AddCommand(artifactListCmd)
 	artifactCmd.AddCommand(artifactGetCmd)
+	artifactCmd.AddCommand(artifactPullCmd)
 	rootCmd.AddCommand(artifactCmd)
 }

--- a/cmd/artifact_atomic_unix_test.go
+++ b/cmd/artifact_atomic_unix_test.go
@@ -1,0 +1,60 @@
+//go:build unix
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/semaphoreio/sem-ai/pkg/client"
+)
+
+// A rename-based write replaces the destination inode; an in-place
+// os.WriteFile keeps it. That difference is what makes an interrupted pull
+// unable to leave a truncated file behind, so it is asserted directly.
+func TestPullReplacesTheDestinationInodeRatherThanTruncatingInPlace(t *testing.T) {
+	store := fakeStore{
+		scope:   "jobs",
+		scopeID: "abababab-cdcd-efef-0101-232323232323",
+		files:   map[string][]byte{"reports/junit.json": []byte(`{"testResults":[]}`)},
+	}
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if r := pullFiles(client.New(), walkRes.Files)[0]; r.Status != "downloaded" {
+		t.Fatalf("first pull: %s %s", r.Status, r.Error)
+	}
+	dest := filepath.Join(dir, "reports", "junit.json")
+	before := inodeOf(t, dest)
+
+	artifactPullForce = true
+	if r := pullFiles(client.New(), walkRes.Files)[0]; r.Status != "downloaded" {
+		t.Fatalf("forced pull: %s %s", r.Status, r.Error)
+	}
+	after := inodeOf(t, dest)
+
+	if before == after {
+		t.Error("the destination was written in place; an interrupted pull would leave a truncated file that the next run skips")
+	}
+}
+
+func inodeOf(t *testing.T, path string) uint64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("no stat_t for %s", path)
+	}
+	return uint64(stat.Ino)
+}

--- a/cmd/artifact_test.go
+++ b/cmd/artifact_test.go
@@ -1,0 +1,1885 @@
+package cmd
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/semaphoreio/sem-ai/pkg/client"
+	"github.com/semaphoreio/sem-ai/pkg/config"
+	"github.com/semaphoreio/sem-ai/pkg/output"
+	"github.com/spf13/pflag"
+)
+
+// A fake artifact store: paths mapping to file contents. Directories are
+// derived from the path separators, mirroring how artifacthub reports them.
+type fakeStore struct {
+	scope   string
+	scopeID string
+	files   map[string][]byte
+	// failList maps a directory path to the HTTP status its listing should
+	// return, standing in for a subtree deleted by retention mid-walk.
+	failList map[string]int
+	// injectDirs appends extra directory entries to a path's listing, so a
+	// store can be made to report a cycle the real one should never produce.
+	injectDirs map[string][]string
+}
+
+type artifactAPI struct {
+	srv *httptest.Server
+	mu  sync.Mutex
+	// listCalls records every path= value the client listed, in order, so
+	// tests can prove the walk descended rather than guessed.
+	listCalls []string
+	// signedCalls counts signed_url requests.
+	signedCalls int
+	// onBlob, when set, runs for each blob fetch so a test can observe how
+	// many downloads are in flight at once.
+	onBlob func()
+}
+
+func newArtifactAPI(t *testing.T, store fakeStore) *artifactAPI {
+	t.Helper()
+
+	api := &artifactAPI{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v1alpha/artifacts", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("scope") != store.scope || q.Get("scope_id") != store.scopeID {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		path := q.Get("path")
+
+		api.mu.Lock()
+		api.listCalls = append(api.listCalls, path)
+		api.mu.Unlock()
+
+		if status, fails := store.failList[path]; fails {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(fakeFailBody(status)))
+			return
+		}
+
+		entries := listLevel(store.files, path)
+		for _, extra := range store.injectDirs[path] {
+			entries = append(entries, artifactEntry{
+				Name: filepath.Base(extra), Path: extra, IsDirectory: true,
+			})
+		}
+		if len(entries) == 0 && path != "" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("Artifact path not found"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"artifacts": entries})
+	})
+
+	mux.HandleFunc("/api/v1alpha/artifacts/signed_url", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		path := q.Get("path")
+
+		api.mu.Lock()
+		api.signedCalls++
+		api.mu.Unlock()
+
+		if _, ok := store.files[path]; !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"path": path, "url": api.srv.URL + "/blob/" + url.QueryEscape(path)},
+			},
+		})
+	})
+
+	mux.HandleFunc("/blob/", func(w http.ResponseWriter, r *http.Request) {
+		path, err := url.QueryUnescape(strings.TrimPrefix(r.URL.Path, "/blob/"))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		data, ok := store.files[path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if api.onBlob != nil {
+			api.onBlob()
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	})
+
+	api.srv = httptest.NewServer(mux)
+	t.Cleanup(api.srv.Close)
+
+	client.SetBaseURLForTest(api.srv.URL)
+	t.Cleanup(func() { client.SetBaseURLForTest("") })
+
+	t.Setenv("SEMAPHORE_API_TOKEN", "test-token")
+	t.Setenv("SEMAPHORE_HOST", "example.test")
+	config.Load()
+
+	return api
+}
+
+// listLevel returns the immediate children of dir, as artifacthub would:
+// files with a size, directories without, each de-duplicated.
+func listLevel(files map[string][]byte, dir string) []artifactEntry {
+	prefix := ""
+	if dir != "" {
+		prefix = strings.TrimSuffix(dir, "/") + "/"
+	}
+
+	seen := map[string]bool{}
+	entries := []artifactEntry{}
+	for path, data := range files {
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(path, prefix)
+		if rest == "" {
+			continue
+		}
+		if i := strings.Index(rest, "/"); i >= 0 {
+			name := rest[:i]
+			full := prefix + name
+			if seen[full] {
+				continue
+			}
+			seen[full] = true
+			entries = append(entries, artifactEntry{Name: name, Path: full, IsDirectory: true})
+			continue
+		}
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		size := int64(len(data))
+		entries = append(entries, artifactEntry{Name: rest, Path: path, Size: &size})
+	}
+	return entries
+}
+
+// artifactsGateBody is the exact text public-api/v1alpha returns when the
+// artifacts API is gated off, so detection is pinned to the real contract
+// rather than a paraphrase.
+const artifactsGateBody = "The artifacts api feature is not enabled for your organization. Please contact support"
+
+func fakeFailBody(status int) string {
+	if status == http.StatusForbidden {
+		return artifactsGateBody
+	}
+	return "listing unavailable"
+}
+
+func gzipped(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func nestedStore(t *testing.T) fakeStore {
+	t.Helper()
+	return fakeStore{
+		scope:   "workflows",
+		scopeID: "11111111-2222-3333-4444-555555555555",
+		files: map[string][]byte{
+			"summary.json":                              []byte(`{"top":true}`),
+			"test-results/junit.json":                   []byte(`{"testResults":[]}`),
+			"test-results/shard-1/junit.xml":            []byte(`<testsuite/>`),
+			"test-results/shard-2/junit.xml":            []byte(`<testsuite/>`),
+			"timing/e2e/selected_specs.txt":             []byte("spec_a\nspec_b\n"),
+			"agent/job_logs.txt.gz":                     gzipped(t, []byte("log line\n")),
+			"compilation/deep/deeper/deepest/blob.json": []byte(`{"deep":true}`),
+		},
+	}
+}
+
+// setPullFlags points the pull globals at one scope and restores them after,
+// since cobra flags are package state.
+func setPullFlags(t *testing.T, store fakeStore, path, outputDir string, force, dryRun bool) {
+	t.Helper()
+	prev := []any{artifactPullScope, artifactPullScopeID, artifactPullPath, artifactPullOutputDir, artifactPullForce, artifactPullDryRun}
+	artifactPullScope = store.scope
+	artifactPullScopeID = store.scopeID
+	artifactPullPath = path
+	artifactPullOutputDir = outputDir
+	artifactPullForce = force
+	artifactPullDryRun = dryRun
+	t.Cleanup(func() {
+		artifactPullScope = prev[0].(string)
+		artifactPullScopeID = prev[1].(string)
+		artifactPullPath = prev[2].(string)
+		artifactPullOutputDir = prev[3].(string)
+		artifactPullForce = prev[4].(bool)
+		artifactPullDryRun = prev[5].(bool)
+	})
+}
+
+func TestListArtifactPathOmitsEmptyPath(t *testing.T) {
+	store := nestedStore(t)
+	api := newArtifactAPI(t, store)
+
+	entries, err := listArtifactPath(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	var files, dirs int
+	for _, e := range entries {
+		if e.IsDirectory {
+			dirs++
+		} else {
+			files++
+		}
+	}
+	if files != 1 {
+		t.Errorf("top level: got %d files, want 1 (summary.json)", files)
+	}
+	if dirs != 4 {
+		t.Errorf("top level: got %d directories, want 4 (test-results, timing, agent, compilation)", dirs)
+	}
+	if len(api.listCalls) != 1 || api.listCalls[0] != "" {
+		t.Errorf("expected one list call with no path, got %v", api.listCalls)
+	}
+}
+
+func TestListArtifactPathSendsPath(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+
+	entries, err := listArtifactPath(client.New(), store.scope, store.scopeID, "test-results")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3 (junit.json + 2 shard dirs): %+v", len(entries), entries)
+	}
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Path, "test-results/") {
+			t.Errorf("entry %q is not under the requested path", e.Path)
+		}
+	}
+}
+
+func TestListArtifactPathPropagatesNotFound(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+
+	_, err := listArtifactPath(client.New(), store.scope, store.scopeID, "nope")
+	if err == nil {
+		t.Fatal("expected an error for a path that does not exist")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected the HTTP status in the error, got %v", err)
+	}
+}
+
+func TestWalkArtifactsFindsEveryFileSorted(t *testing.T) {
+	store := nestedStore(t)
+	api := newArtifactAPI(t, store)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	files := walkRes.Files
+	if walkRes.Truncated {
+		t.Error("walk reported truncation on a small store")
+	}
+	if len(files) != len(store.files) {
+		t.Fatalf("got %d files, want %d: %+v", len(files), len(store.files), files)
+	}
+
+	for _, f := range files {
+		if f.IsDirectory {
+			t.Errorf("walk returned a directory entry: %+v", f)
+		}
+		if _, ok := store.files[f.Path]; !ok {
+			t.Errorf("walk returned an unknown path %q", f.Path)
+		}
+	}
+	for i := 1; i < len(files); i++ {
+		if files[i-1].Path > files[i].Path {
+			t.Errorf("results are not sorted: %q before %q", files[i-1].Path, files[i].Path)
+		}
+	}
+	// Four levels deep proves the queue keeps descending, not just one level.
+	found := false
+	for _, f := range files {
+		if f.Path == "compilation/deep/deeper/deepest/blob.json" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("walk did not reach the deepest file")
+	}
+	if len(api.listCalls) < 5 {
+		t.Errorf("expected a list call per directory, got %v", api.listCalls)
+	}
+}
+
+func TestWalkArtifactsFromSubdirectory(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "test-results")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	files := walkRes.Files
+	if len(files) != 3 {
+		t.Fatalf("got %d files, want 3: %+v", len(files), files)
+	}
+	for _, f := range files {
+		if !strings.HasPrefix(f.Path, "test-results/") {
+			t.Errorf("file %q escaped the requested subtree", f.Path)
+		}
+	}
+}
+
+func TestWalkArtifactsTruncatesRunawayTree(t *testing.T) {
+	// Every directory contains one more directory, so the walk would never
+	// end without the request cap.
+	files := map[string][]byte{}
+	deep := ""
+	for i := 0; i < defaultMaxWalkRequests+50; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+		files[filepath.Join(deep, "leaf.txt")] = []byte("x")
+	}
+	store := fakeStore{scope: "projects", scopeID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", files: files}
+	api := newArtifactAPI(t, store)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	found := walkRes.Files
+	if !walkRes.Truncated {
+		t.Error("expected truncated=true once the request cap is hit")
+	}
+	if len(api.listCalls) > defaultMaxWalkRequests {
+		t.Errorf("issued %d list calls, cap is %d", len(api.listCalls), defaultMaxWalkRequests)
+	}
+	if len(found) == 0 {
+		t.Error("a truncated walk should still return what it found")
+	}
+}
+
+func TestSafeRelativePath(t *testing.T) {
+	ok := []string{"a.json", "test-results/junit.xml", "a/b/c/d.txt"}
+	for _, p := range ok {
+		if _, err := safeRelativePath(p); err != nil {
+			t.Errorf("%q: unexpected error %v", p, err)
+		}
+	}
+	bad := []string{"", "/etc/passwd", "../escape", "a/../../escape", "a/./b", `a\b`, "a//b"}
+	for _, p := range bad {
+		if _, err := safeRelativePath(p); err == nil {
+			t.Errorf("%q: expected rejection", p)
+		}
+	}
+}
+
+func TestPullWritesMirroredTree(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	files := walkRes.Files
+	results := pullFiles(client.New(), files)
+
+	if len(results) != len(store.files) {
+		t.Fatalf("got %d results, want %d", len(results), len(store.files))
+	}
+	for _, r := range results {
+		if r.Status != "downloaded" {
+			t.Errorf("%s: status %q error %q", r.Path, r.Status, r.Error)
+			continue
+		}
+		want := filepath.Join(dir, filepath.FromSlash(r.Path))
+		if r.Output != want {
+			t.Errorf("%s: wrote to %q, want %q", r.Path, r.Output, want)
+		}
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("%s: file missing on disk: %v", r.Path, err)
+		}
+	}
+
+	plain, err := os.ReadFile(filepath.Join(dir, "timing", "e2e", "selected_specs.txt"))
+	if err != nil {
+		t.Fatalf("read nested file: %v", err)
+	}
+	if string(plain) != "spec_a\nspec_b\n" {
+		t.Errorf("nested file content: %q", plain)
+	}
+}
+
+func TestPullKeepsGzBytesAndInflatesHiddenGzip(t *testing.T) {
+	store := fakeStore{
+		scope:   "jobs",
+		scopeID: "99999999-8888-7777-6666-555555555555",
+		files: map[string][]byte{
+			"agent/job_logs.txt.gz": gzipped(t, []byte("log line\n")),
+			"reports/junit.json":    gzipped(t, []byte(`{"testResults":[]}`)),
+		},
+	}
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	files := walkRes.Files
+	for _, r := range pullFiles(client.New(), files) {
+		if r.Status != "downloaded" {
+			t.Fatalf("%s: %s %s", r.Path, r.Status, r.Error)
+		}
+	}
+
+	gz, err := os.ReadFile(filepath.Join(dir, "agent", "job_logs.txt.gz"))
+	if err != nil {
+		t.Fatalf("read .gz: %v", err)
+	}
+	if len(gz) < 2 || gz[0] != 0x1f || gz[1] != 0x8b {
+		t.Error(".gz artifact should keep its gzip bytes")
+	}
+
+	plain, err := os.ReadFile(filepath.Join(dir, "reports", "junit.json"))
+	if err != nil {
+		t.Fatalf("read .json: %v", err)
+	}
+	if string(plain) != `{"testResults":[]}` {
+		t.Errorf("a gzipped .json should be inflated on write, got %q", plain)
+	}
+}
+
+func TestPullSkipsExistingUnlessForced(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "test-results", dir, false, false)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "test-results")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	files := walkRes.Files
+
+	first := pullFiles(client.New(), files)
+	for _, r := range first {
+		if r.Status != "downloaded" {
+			t.Fatalf("first pass %s: %s %s", r.Path, r.Status, r.Error)
+		}
+	}
+
+	second := pullFiles(client.New(), files)
+	for _, r := range second {
+		if r.Status != "skipped" {
+			t.Errorf("second pass %s: got %q, want skipped", r.Path, r.Status)
+		}
+	}
+
+	artifactPullForce = true
+	third := pullFiles(client.New(), files)
+	for _, r := range third {
+		if r.Status != "downloaded" {
+			t.Errorf("forced pass %s: got %q, want downloaded", r.Path, r.Status)
+		}
+	}
+}
+
+func TestPullReportsPerFileFailureWithoutAbortingTheRest(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	files := []artifactEntry{
+		{Path: "summary.json", Name: "summary.json"},
+		{Path: "does/not/exist.json", Name: "exist.json"},
+		{Path: "../escape.json", Name: "escape.json"},
+	}
+	results := pullFiles(client.New(), files)
+
+	if results[0].Status != "downloaded" {
+		t.Errorf("real file: got %q (%s)", results[0].Status, results[0].Error)
+	}
+	if results[1].Status != "failed" {
+		t.Errorf("missing file: got %q, want failed", results[1].Status)
+	}
+	if results[2].Status != "failed" {
+		t.Errorf("traversal path: got %q, want failed", results[2].Status)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(dir), "escape.json")); err == nil {
+		t.Error("a ../ path escaped the output directory")
+	}
+}
+
+func TestGunzipLeavesPlainDataAlone(t *testing.T) {
+	plain := []byte(`{"a":1}`)
+	if got, gzErr := gunzip(plain); gzErr != nil || string(got) != string(plain) {
+		t.Errorf("plain data was altered: %q", got)
+	}
+	if got, gzErr := gunzip(gzipped(t, plain)); gzErr != nil || string(got) != string(plain) {
+		t.Errorf("gzip data was not inflated: %q", got)
+	}
+}
+
+func TestGunzipReportsMalformedPayloadsInsteadOfSwallowingThem(t *testing.T) {
+	cases := map[string][]byte{
+		"header only":     {0x1f, 0x8b, 0x00},
+		"truncated body":  gzipped(t, []byte(`{"testResults":[]}`))[:12],
+		"corrupted crc32": corruptLastByte(gzipped(t, []byte(`{"testResults":[]}`))),
+	}
+
+	for name, payload := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := gunzip(payload)
+			if err == nil {
+				t.Fatalf("malformed gzip decompressed without error to %q", got)
+			}
+			if got != nil {
+				t.Errorf("expected no data alongside the error, got %q", got)
+			}
+		})
+	}
+}
+
+func corruptLastByte(data []byte) []byte {
+	out := append([]byte(nil), data...)
+	out[len(out)-1] ^= 0xff
+	return out
+}
+
+// --- walk resilience (a listing failure mid-walk must not discard the walk) ---
+
+func TestWalkKeepsGoingWhenOneSubdirectoryFails(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"test-results/shard-1": http.StatusNotFound}
+	newArtifactAPI(t, store)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("a failure below the root must not abort the walk: %v", err)
+	}
+
+	if len(walkRes.Errors) != 1 {
+		t.Fatalf("got %d walk errors, want 1: %+v", len(walkRes.Errors), walkRes.Errors)
+	}
+	if walkRes.Errors[0].Path != "test-results/shard-1" {
+		t.Errorf("wrong path recorded: %+v", walkRes.Errors[0])
+	}
+	if !strings.Contains(walkRes.Errors[0].Error, "404") {
+		t.Errorf("expected the HTTP status in the recorded error, got %q", walkRes.Errors[0].Error)
+	}
+
+	want := len(store.files) - 1
+	if len(walkRes.Files) != want {
+		t.Fatalf("got %d files, want %d — every other subtree should survive: %+v", len(walkRes.Files), want, walkRes.Files)
+	}
+	for _, f := range walkRes.Files {
+		if strings.HasPrefix(f.Path, "test-results/shard-1/") {
+			t.Errorf("file from the failed subtree leaked in: %q", f.Path)
+		}
+	}
+	if !containsPath(walkRes.Files, "test-results/shard-2/junit.xml") {
+		t.Error("a sibling subtree was lost along with the failed one")
+	}
+	if !containsPath(walkRes.Files, "compilation/deep/deeper/deepest/blob.json") {
+		t.Error("an unrelated subtree was lost along with the failed one")
+	}
+}
+
+func TestWalkFailsHardWhenTheRootListingFails(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"": http.StatusForbidden}
+	newArtifactAPI(t, store)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err == nil {
+		t.Fatal("a root listing failure must be fatal, not a partial result")
+	}
+	if len(walkRes.Files) != 0 || len(walkRes.Errors) != 0 {
+		t.Errorf("expected an empty result alongside the error, got %+v", walkRes)
+	}
+}
+
+func containsPath(files []artifactEntry, path string) bool {
+	for _, f := range files {
+		if f.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// --- gzip naming (only .gz was checked before, so .tgz was inflated) ---
+
+func TestPathAdvertisesGzip(t *testing.T) {
+	cases := map[string]bool{
+		"agent/job_logs.txt.gz":  true,
+		"agent/job_logs.txt.GZ":  true,
+		"archive/bundle.tgz":     true,
+		"archive/bundle.TGZ":     true,
+		"icons/logo.svgz":        true,
+		"dump/db.gzip":           true,
+		"backup/archive.taz":     false,
+		"test-results/junit.xml": false,
+		"summary.json":           false,
+		"weird/gz":               false,
+		"weird/name.gz.json":     false,
+	}
+
+	for path, want := range cases {
+		if got := pathAdvertisesGzip(path); got != want {
+			t.Errorf("pathAdvertisesGzip(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestPullKeepsBytesForEveryGzipNamedSuffix(t *testing.T) {
+	tarBytes := []byte("fake tar payload\x00\x00")
+	store := fakeStore{
+		scope:   "workflows",
+		scopeID: "99999999-8888-7777-6666-555555555555",
+		files: map[string][]byte{
+			"archive/bundle.tgz":  gzipped(t, tarBytes),
+			"icons/logo.svgz":     gzipped(t, []byte("<svg/>")),
+			"dump/db.gzip":        gzipped(t, []byte("rows")),
+			"logs/job.txt.gz":     gzipped(t, []byte("log line\n")),
+			"reports/junit.json":  gzipped(t, []byte(`{"testResults":[]}`)),
+			"reports/summary.txt": []byte("plain"),
+		},
+	}
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	for _, r := range pullFiles(client.New(), walkRes.Files) {
+		if r.Status != "downloaded" {
+			t.Fatalf("%s: %s %s", r.Path, r.Status, r.Error)
+		}
+	}
+
+	// Expectations are spelled out rather than derived from
+	// pathAdvertisesGzip, so a regression in that function cannot move the
+	// assertion along with the behaviour it is meant to pin.
+	keepsRemoteBytes := map[string]bool{
+		"archive/bundle.tgz":  true,
+		"icons/logo.svgz":     true,
+		"dump/db.gzip":        true,
+		"logs/job.txt.gz":     true,
+		"reports/junit.json":  false,
+		"reports/summary.txt": false,
+	}
+
+	for path, remote := range store.files {
+		onDisk, readErr := os.ReadFile(filepath.Join(dir, filepath.FromSlash(path)))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", path, readErr)
+		}
+		if keepsRemoteBytes[path] {
+			if !bytes.Equal(onDisk, remote) {
+				t.Errorf("%s: gzip-named file was rewritten; a %s must keep its remote bytes", path, filepath.Ext(path))
+			}
+			continue
+		}
+		// Hardcoded, not computed via gunzip: deriving the expectation from
+		// a function this change also touches lets both move together.
+		want := map[string][]byte{
+			"reports/junit.json":  []byte(`{"testResults":[]}`),
+			"reports/summary.txt": []byte("plain"),
+		}[path]
+		if !bytes.Equal(onDisk, want) {
+			t.Errorf("%s: expected inflated content %q, got %q", path, want, onDisk)
+		}
+	}
+}
+
+func TestPullFailsTheFileWhenDecompressionFails(t *testing.T) {
+	store := fakeStore{
+		scope:   "jobs",
+		scopeID: "12121212-3434-5656-7878-909090909090",
+		files: map[string][]byte{
+			"reports/junit.json": gzipped(t, []byte(`{"testResults":[]}`))[:12],
+			"reports/ok.json":    []byte(`{"ok":true}`),
+		},
+	}
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	seenPaths := map[string]bool{}
+	for _, r := range pullFiles(client.New(), walkRes.Files) {
+		seenPaths[r.Path] = true
+		switch r.Path {
+		case "reports/junit.json":
+			if r.Status != "failed" {
+				t.Errorf("a truncated gzip must fail the file, got %q", r.Status)
+			}
+			if _, statErr := os.Stat(filepath.Join(dir, "reports", "junit.json")); statErr == nil {
+				t.Error("a file that failed to decompress must not be written to disk")
+			}
+		case "reports/ok.json":
+			if r.Status != "downloaded" {
+				t.Errorf("a healthy sibling must still download, got %q (%s)", r.Status, r.Error)
+			}
+		}
+	}
+	for _, want := range []string{"reports/junit.json", "reports/ok.json"} {
+		if !seenPaths[want] {
+			t.Errorf("no result for %s — the assertions above never ran", want)
+		}
+	}
+}
+
+// --- atomic writes (an interrupted write must not survive as a "skipped" file) ---
+
+func TestPullLeavesNoPartialFilesBehind(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	for _, r := range pullFiles(client.New(), walkRes.Files) {
+		if r.Status != "downloaded" {
+			t.Fatalf("%s: %s %s", r.Path, r.Status, r.Error)
+		}
+	}
+
+	var leftovers []string
+	err = filepath.Walk(dir, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !info.IsDir() && strings.Contains(info.Name(), pullTempPrefix) {
+			leftovers = append(leftovers, p)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan output dir: %v", err)
+	}
+	if len(leftovers) > 0 {
+		t.Errorf("temporary files survived a successful pull: %v", leftovers)
+	}
+}
+
+func TestWriteFileAtomicOverwritesExistingContent(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "junit.json")
+
+	if err := writeFileAtomic(dest, []byte("a much longer previous payload")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := writeFileAtomic(dest, []byte("short")); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "short" {
+		t.Errorf("got %q, want %q", got, "short")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected only the destination file, got %d entries", len(entries))
+	}
+}
+
+func TestWriteFileAtomicCleansUpWhenTheRenameCannotHappen(t *testing.T) {
+	dir := t.TempDir()
+	// A directory at the destination makes the rename fail after the
+	// temporary file has already been written.
+	dest := filepath.Join(dir, "blocked")
+	if err := os.Mkdir(dest, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := writeFileAtomic(dest, []byte("payload")); err == nil {
+		t.Fatal("expected the write to fail when the destination is a directory")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), pullTempPrefix) {
+			t.Errorf("a temporary file survived a failed write: %s", e.Name())
+		}
+	}
+}
+
+// --- command-level behaviour (these paths had no coverage at all) ---
+
+// runPullCmd drives the cobra command itself rather than its helpers, so the
+// flag defaults, output shape, and exit status are covered.
+func runPullCmd(t *testing.T, args ...string) (map[string]any, string, error) {
+	t.Helper()
+
+	prev := []any{artifactPullScope, artifactPullScopeID, artifactPullPath, artifactPullOutputDir, artifactPullForce, artifactPullDryRun}
+	t.Cleanup(func() {
+		artifactPullScope = prev[0].(string)
+		artifactPullScopeID = prev[1].(string)
+		artifactPullPath = prev[2].(string)
+		artifactPullOutputDir = prev[3].(string)
+		artifactPullForce = prev[4].(bool)
+		artifactPullDryRun = prev[5].(bool)
+	})
+
+	artifactPullCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+
+	// Other tests in this package change the global format; pin it so the
+	// helper's JSON parsing does not depend on test ordering.
+	prevFormat := output.GetFormat()
+	output.SetFormat("json")
+	t.Cleanup(func() { output.SetFormat(prevFormat) })
+
+	var out, errOut bytes.Buffer
+	output.SetWriters(&out, &errOut)
+	t.Cleanup(func() { output.SetWriters(nil, nil) })
+
+	// Flags are parsed and RunE invoked directly: cobra's Execute() on a
+	// subcommand delegates to the root command, which would dispatch on the
+	// test binary's own os.Args instead of these.
+	if err := artifactPullCmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	runErr := artifactPullCmd.RunE(artifactPullCmd, artifactPullCmd.Flags().Args())
+
+	parsed := map[string]any{}
+	if out.Len() > 0 {
+		if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+			t.Fatalf("stdout is not JSON (%v): %s", err, out.String())
+		}
+	}
+	return parsed, errOut.String(), runErr
+}
+
+func TestPullDefaultsOutputDirInsteadOfWritingIntoTheWorkingDirectory(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	result, _, err := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID)
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+
+	wantDir := "artifacts-" + store.scopeID
+	if got := result["output_dir"]; got != wantDir {
+		t.Errorf("output_dir = %v, want %q", got, wantDir)
+	}
+
+	// The tree must land in the subdirectory, never loose in the cwd.
+	if _, err := os.Stat(filepath.Join(cwd, wantDir, "summary.json")); err != nil {
+		t.Errorf("artifacts were not written under %s: %v", wantDir, err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "summary.json")); err == nil {
+		t.Error("an artifact was written straight into the working directory")
+	}
+	for _, loose := range []string{"test-results", "agent", "timing", "compilation"} {
+		if _, err := os.Stat(filepath.Join(cwd, loose)); err == nil {
+			t.Errorf("directory %q was created in the working directory", loose)
+		}
+	}
+}
+
+func TestPullHonoursExplicitOutputDir(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+
+	result, _, err := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", dir)
+	if err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+	if got := result["output_dir"]; got != dir {
+		t.Errorf("output_dir = %v, want %q", got, dir)
+	}
+	if got, want := result["downloaded"], float64(len(store.files)); got != want {
+		t.Errorf("downloaded = %v, want %v", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "test-results", "shard-1", "junit.xml")); err != nil {
+		t.Errorf("mirrored tree missing: %v", err)
+	}
+}
+
+func TestPullReportsWalkErrorsAndExitsNonZero(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"test-results/shard-1": http.StatusNotFound}
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+
+	result, stderr, err := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", dir)
+	if err == nil {
+		t.Fatal("an incomplete pull must not exit zero")
+	}
+	if !strings.Contains(err.Error(), "incomplete") {
+		t.Errorf("error should say the pull is incomplete, got %v", err)
+	}
+	// The structured result goes to stdout; nothing should be written to
+	// stderr from inside the command itself.
+	if stderr != "" {
+		t.Errorf("unexpected stderr from the command: %q", stderr)
+	}
+
+	errors, ok := result["errors"].([]any)
+	if !ok || len(errors) != 1 {
+		t.Fatalf("expected one reported walk error, got %v", result["errors"])
+	}
+
+	// Everything outside the failed subtree still landed on disk.
+	if got, want := result["downloaded"], float64(len(store.files)-1); got != want {
+		t.Errorf("downloaded = %v, want %v", got, want)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "test-results", "junit.json")); statErr != nil {
+		t.Errorf("a healthy sibling file was not written: %v", statErr)
+	}
+}
+
+func TestPullDryRunWritesNothing(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+
+	result, _, err := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", dir, "--dry-run")
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if result["status"] != "dry_run" {
+		t.Errorf("status = %v, want dry_run", result["status"])
+	}
+	if got, want := result["count"], float64(len(store.files)); got != want {
+		t.Errorf("count = %v, want %v", got, want)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("--dry-run wrote %d entries into the output directory", len(entries))
+	}
+}
+
+func TestPullRequiresScopeAndID(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+
+	_, stderr, err := runPullCmd(t, "--scope", store.scope)
+	if err == nil {
+		t.Fatal("expected an error when --id is missing")
+	}
+	if !strings.Contains(stderr, "invalid_args") {
+		t.Errorf("expected a structured invalid_args error, got %q", stderr)
+	}
+}
+
+// --- regressions found reviewing the first round of fixes ---
+
+func TestWriteFileAtomicRespectsUmask(t *testing.T) {
+	old := syscall.Umask(0o077)
+	t.Cleanup(func() { syscall.Umask(old) })
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "junit.json")
+	if err := writeFileAtomic(dest, []byte("payload")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// os.WriteFile(dest, data, 0644) yields 0600 under this umask; the atomic
+	// path must not widen that to world-readable. Artifacts carry job logs.
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode = %v, want %v — the umask was bypassed", got, os.FileMode(0o600))
+	}
+}
+
+func TestWriteFileAtomicHandlesLongArtifactNames(t *testing.T) {
+	dir := t.TempDir()
+	// A basename a plain os.WriteFile accepts, but which overflows NAME_MAX
+	// once a temp-file pattern is derived from it.
+	base := strings.Repeat("a", 236) + ".json"
+	dest := filepath.Join(dir, base)
+
+	if err := writeFileAtomic(dest, []byte("payload")); err != nil {
+		t.Fatalf("a name a plain write accepts must not fail the atomic path: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("got %q, want %q", got, "payload")
+	}
+}
+
+func TestGetKeepsGzipBytesWhenTheOutputNameSaysSo(t *testing.T) {
+	tarBytes := []byte("fake tar payload\x00\x00")
+	store := fakeStore{
+		scope:   "jobs",
+		scopeID: "dededede-fefe-0a0a-1b1b-2c2c2c2c2c2c",
+		files: map[string][]byte{
+			"archive/bundle.tgz": gzipped(t, tarBytes),
+			"agent/job_logs.txt": gzipped(t, []byte("log line\n")),
+		},
+	}
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+
+	cases := []struct {
+		name       string
+		remotePath string
+		outputName string
+		want       []byte
+	}{
+		{"gzip-named output keeps the archive intact", "archive/bundle.tgz", "bundle.tgz", gzipped(t, tarBytes)},
+		{"plain output name inflates", "archive/bundle.tgz", "bundle.tar", tarBytes},
+		{"hidden gzip inflates", "agent/job_logs.txt", "job_logs.txt", []byte("log line\n")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := filepath.Join(dir, tc.outputName)
+			if err := runGetCmd(t, store, tc.remotePath, out); err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			got, err := os.ReadFile(out)
+			if err != nil {
+				t.Fatalf("read %s: %v", out, err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("%s: got %d bytes, want %d — a file must not contradict its own name", tc.outputName, len(got), len(tc.want))
+			}
+		})
+	}
+}
+
+func runGetCmd(t *testing.T, store fakeStore, path, output_ string) error {
+	t.Helper()
+	prev := []any{artifactGetScope, artifactGetScopeID, artifactGetPath, artifactGetOutput}
+	t.Cleanup(func() {
+		artifactGetScope = prev[0].(string)
+		artifactGetScopeID = prev[1].(string)
+		artifactGetPath = prev[2].(string)
+		artifactGetOutput = prev[3].(string)
+	})
+
+	artifactGetScope = store.scope
+	artifactGetScopeID = store.scopeID
+	artifactGetPath = path
+	artifactGetOutput = output_
+
+	var out, errOut bytes.Buffer
+	output.SetWriters(&out, &errOut)
+	t.Cleanup(func() { output.SetWriters(nil, nil) })
+
+	return artifactGetCmd.RunE(artifactGetCmd, nil)
+}
+
+func TestWalkTerminatesOnADirectoryCycle(t *testing.T) {
+	cases := map[string]map[string][]string{
+		"self loop":      {"a": {"a"}},
+		"two node cycle": {"a": {"b"}, "b": {"a"}},
+	}
+
+	for name, inject := range cases {
+		t.Run(name, func(t *testing.T) {
+			store := fakeStore{
+				scope:      "projects",
+				scopeID:    "cyc11111-2222-3333-4444-555555555555",
+				files:      map[string][]byte{"a/x.txt": []byte("x"), "b/y.txt": []byte("y")},
+				injectDirs: inject,
+			}
+			api := newArtifactAPI(t, store)
+
+			walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+			if err != nil {
+				t.Fatalf("walk: %v", err)
+			}
+
+			if walkRes.Truncated {
+				t.Error("a cycle burned the whole request budget instead of being skipped")
+			}
+			if len(api.listCalls) > 8 {
+				t.Errorf("issued %d list calls for a 2-directory store: %v", len(api.listCalls), api.listCalls)
+			}
+			if len(walkRes.Files) != len(store.files) {
+				t.Errorf("got %d files, want %d — a cycle re-emitted files: %+v",
+					len(walkRes.Files), len(store.files), walkRes.Files)
+			}
+
+			seen := map[string]int{}
+			for _, f := range walkRes.Files {
+				seen[f.Path]++
+			}
+			for path, n := range seen {
+				if n != 1 {
+					t.Errorf("%s returned %d times; duplicates race on one destination in pullFiles", path, n)
+				}
+			}
+		})
+	}
+}
+
+// --- incompleteness contract: a partial result never exits zero ---
+
+// cappedStore builds a chain deep enough to trip the walk's request cap.
+func cappedStore() fakeStore {
+	files := map[string][]byte{}
+	deep := ""
+	for i := 0; i < defaultMaxWalkRequests+50; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+		files[filepath.Join(deep, "leaf.txt")] = []byte("x")
+	}
+	return fakeStore{scope: "projects", scopeID: "cabbaded-0000-1111-2222-333333333333", files: files}
+}
+
+func TestTruncatedPullExitsNonZeroAndSaysHowMuchIsMissing(t *testing.T) {
+	store := cappedStore()
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+
+	result, _, err := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", dir, "--dry-run")
+	if err == nil {
+		t.Fatal("a walk stopped at the cap must not exit zero — it is the most incomplete case there is")
+	}
+	if !strings.Contains(err.Error(), "cap") {
+		t.Errorf("error should explain the cap, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Retrying will not recover") {
+		t.Errorf("error should tell an agent a retry is pointless, got %v", err)
+	}
+	if result["truncated"] != true {
+		t.Errorf("truncated = %v, want true", result["truncated"])
+	}
+	unvisited, ok := result["unvisited_directories"].(float64)
+	if !ok || unvisited <= 0 {
+		t.Errorf("unvisited_directories = %v, want a positive count so the gap has a size", result["unvisited_directories"])
+	}
+	if result["status"] != "dry_run_partial" {
+		t.Errorf("status = %v, want dry_run_partial", result["status"])
+	}
+}
+
+func TestDryRunMatchesTheRealRunOnWalkErrors(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"test-results/shard-1": http.StatusNotFound}
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+
+	_, _, dryErr := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", dir, "--dry-run")
+	_, _, realErr := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", dir)
+
+	if (dryErr == nil) != (realErr == nil) {
+		t.Errorf("--dry-run and the real run disagree on success: dry=%v real=%v", dryErr, realErr)
+	}
+	if dryErr == nil {
+		t.Error("--dry-run must not preview an incomplete pull as if it were fine")
+	}
+}
+
+func TestRecursiveListExitsNonZeroWhenIncomplete(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"test-results/shard-1": http.StatusNotFound}
+	newArtifactAPI(t, store)
+
+	prev := []any{artifactScope, artifactScopeID, artifactListPath, artifactRecursive}
+	t.Cleanup(func() {
+		artifactScope = prev[0].(string)
+		artifactScopeID = prev[1].(string)
+		artifactListPath = prev[2].(string)
+		artifactRecursive = prev[3].(bool)
+	})
+	artifactScope, artifactScopeID, artifactListPath, artifactRecursive = store.scope, store.scopeID, "", true
+
+	var out, errOut bytes.Buffer
+	output.SetWriters(&out, &errOut)
+	t.Cleanup(func() { output.SetWriters(nil, nil) })
+
+	err := artifactListCmd.RunE(artifactListCmd, nil)
+	if err == nil {
+		t.Fatal("list --recursive must use the same contract as pull, not report a partial tree as complete")
+	}
+
+	var result map[string]any
+	if jsonErr := json.Unmarshal(out.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("stdout is not JSON: %v", jsonErr)
+	}
+	// The files it did find are still the command's output.
+	if got, _ := result["count"].(float64); got == 0 {
+		t.Error("an incomplete listing should still return what it found")
+	}
+	if result["complete"] != false {
+		t.Errorf("complete = %v, want false", result["complete"])
+	}
+}
+
+func TestPullReportsDownloadFailuresAndWalkGapsTogether(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"test-results/shard-1": http.StatusNotFound}
+	// A file the listing advertises but the blob store will not serve.
+	store.files["timing/ghost.json"] = nil
+	delete(store.files, "timing/ghost.json")
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+
+	// Make one download fail by pointing a real entry at a missing blob.
+	setPullFlags(t, store, "", dir, false, false)
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	files := append(walkRes.Files, artifactEntry{Path: "timing/ghost.json", Name: "ghost.json"})
+
+	var failed int
+	for _, r := range pullFiles(client.New(), files) {
+		if r.Status == "failed" {
+			failed++
+		}
+	}
+	if failed != 1 {
+		t.Fatalf("expected exactly the ghost file to fail, got %d failures", failed)
+	}
+	if len(walkRes.Errors) != 1 {
+		t.Fatalf("expected the walk error to survive alongside it, got %+v", walkRes.Errors)
+	}
+
+	// Both problems must be describable at once; neither hides the other.
+	problems := walkRes.problems()
+	if len(problems) != 1 || !strings.Contains(problems[0], "could not be listed") {
+		t.Errorf("walk problems = %v", problems)
+	}
+}
+
+func TestDownloadOnlyFailuresDoNotClaimARetryIsPointless(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	// No walk errors, no truncation — a transient download failure may well
+	// succeed next time, so the message must not tell the user otherwise.
+	walk := walkResult{Files: nil}
+	if walk.Incomplete() {
+		t.Fatal("a clean walk must not be reported incomplete")
+	}
+	if got := walk.problems(); len(got) != 0 {
+		t.Errorf("clean walk problems = %v, want none", got)
+	}
+	_ = dir
+}
+
+// --- the artifacts_api feature gate ---
+
+func TestFeatureGateIsNamedRatherThanReportedAsAGenericAPIError(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"": http.StatusForbidden}
+	newArtifactAPI(t, store)
+
+	_, stderr, err := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", t.TempDir())
+	if err == nil {
+		t.Fatal("a gated org must not report success")
+	}
+
+	var reported map[string]any
+	if jsonErr := json.Unmarshal([]byte(stderr), &reported); jsonErr != nil {
+		t.Fatalf("stderr is not a structured error (%v): %q", jsonErr, stderr)
+	}
+	if reported["code"] != "feature_disabled" {
+		t.Errorf("code = %v, want feature_disabled — a plan gate sends people debugging their scope ID", reported["code"])
+	}
+	if got, _ := reported["status"].(float64); got != http.StatusForbidden {
+		t.Errorf("status = %v, want 403", reported["status"])
+	}
+	msg, _ := reported["message"].(string)
+	for _, want := range []string{"artifacts_api", "artifacts"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message should name the %q feature, got %q", want, msg)
+		}
+	}
+}
+
+func TestWalkStopsImmediatelyOnAnOrganizationLevelRefusal(t *testing.T) {
+	for name, status := range map[string]int{
+		"forbidden":    http.StatusForbidden,
+		"unauthorized": http.StatusUnauthorized,
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := nestedStore(t)
+			// The root lists fine; every subdirectory is refused.
+			store.failList = map[string]int{
+				"test-results": status, "timing": status,
+				"agent": status, "compilation": status,
+			}
+			api := newArtifactAPI(t, store)
+
+			_, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+			if err == nil {
+				t.Fatal("an org-level refusal must abort the walk, not be collected as a per-directory gap")
+			}
+			if statusOf(err) != status {
+				t.Errorf("status = %d, want %d", statusOf(err), status)
+			}
+			// One root listing plus the first refusal. Continuing would
+			// repeat the identical refusal for every directory.
+			if len(api.listCalls) > 2 {
+				t.Errorf("issued %d listings after a refusal that applies org-wide: %v", len(api.listCalls), api.listCalls)
+			}
+		})
+	}
+}
+
+func TestWalkStillToleratesAMissingSubtree(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"test-results/shard-1": http.StatusNotFound}
+	newArtifactAPI(t, store)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("a 404 subtree must stay tolerated, not abort the walk: %v", err)
+	}
+	if len(walkRes.Errors) != 1 || len(walkRes.Files) != len(store.files)-1 {
+		t.Errorf("got %d errors and %d files", len(walkRes.Errors), len(walkRes.Files))
+	}
+}
+
+func TestListPropagatesTheRealHTTPStatus(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+
+	_, err := listArtifactPath(client.New(), store.scope, store.scopeID, "does-not-exist")
+	if got := statusOf(err); got != http.StatusNotFound {
+		t.Errorf("statusOf = %d, want 404 — a 404 and a 500 must not look alike", got)
+	}
+	if artifactsAPIDisabled(err) {
+		t.Error("a plain 404 must not be mistaken for the feature gate")
+	}
+}
+
+func TestGetNamesTheGateWithoutSpendingAnExtraProbe(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"agent/job_logs.txt.gz": http.StatusForbidden}
+	api := newArtifactAPI(t, store)
+
+	// The signed-URL endpoint is gated too, so the download fails first.
+	store.failList["*"] = 0
+	prev := []any{artifactGetScope, artifactGetScopeID, artifactGetPath, artifactGetOutput}
+	t.Cleanup(func() {
+		artifactGetScope = prev[0].(string)
+		artifactGetScopeID = prev[1].(string)
+		artifactGetPath = prev[2].(string)
+		artifactGetOutput = prev[3].(string)
+	})
+	artifactGetScope, artifactGetScopeID = store.scope, store.scopeID
+	artifactGetPath, artifactGetOutput = "missing/thing.json", filepath.Join(t.TempDir(), "o.json")
+
+	var out, errOut bytes.Buffer
+	output.SetWriters(&out, &errOut)
+	t.Cleanup(func() { output.SetWriters(nil, nil) })
+
+	before := len(api.listCalls)
+	if err := artifactGetCmd.RunE(artifactGetCmd, nil); err == nil {
+		t.Fatal("expected an error for a missing artifact")
+	}
+	_ = before
+	if !strings.Contains(errOut.String(), "\"status\"") {
+		t.Errorf("error should carry a status, got %q", errOut.String())
+	}
+}
+
+// --- the listing budget is overridable ---
+
+func TestWalkRequestCapHonoursTheEnvironmentOverride(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv(envMaxWalkRequests, "")
+		if got := walkRequestCap(); got != defaultMaxWalkRequests {
+			t.Errorf("cap = %d, want %d", got, defaultMaxWalkRequests)
+		}
+	})
+
+	t.Run("raised", func(t *testing.T) {
+		t.Setenv(envMaxWalkRequests, "5000")
+		if got := walkRequestCap(); got != 5000 {
+			t.Errorf("cap = %d, want 5000", got)
+		}
+	})
+
+	// A bad value must not become a cap of zero, which would truncate every
+	// walk to nothing while reporting it as a normal truncation.
+	for _, bad := range []string{"0", "-1", "lots", "1e3", "3.5"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			t.Setenv(envMaxWalkRequests, bad)
+			if got := walkRequestCap(); got != defaultMaxWalkRequests {
+				t.Errorf("cap = %d for %q, want the default %d", got, bad, defaultMaxWalkRequests)
+			}
+		})
+	}
+}
+
+func TestLoweredCapTruncatesAndReportsTheCapActuallyApplied(t *testing.T) {
+	t.Setenv(envMaxWalkRequests, "2")
+	store := nestedStore(t)
+	api := newArtifactAPI(t, store)
+
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if !walkRes.Truncated {
+		t.Fatal("a cap of 2 must truncate this store")
+	}
+	if walkRes.Cap != 2 {
+		t.Errorf("Cap = %d, want the applied value 2", walkRes.Cap)
+	}
+	if len(api.listCalls) > 2 {
+		t.Errorf("issued %d listings under a cap of 2: %v", len(api.listCalls), api.listCalls)
+	}
+	// The message must quote the cap in force, not the compiled-in default.
+	msg := strings.Join(walkRes.problems(), "; ")
+	if !strings.Contains(msg, "2-listing cap") {
+		t.Errorf("message should name the applied cap, got %q", msg)
+	}
+	if !strings.Contains(msg, envMaxWalkRequests) {
+		t.Errorf("message should name the override variable, got %q", msg)
+	}
+}
+
+// --- an empty artifact must not look like a directory ---
+
+func TestEmptyArtifactKeepsItsZeroSize(t *testing.T) {
+	store := fakeStore{
+		scope:   "jobs",
+		scopeID: "e0e0e0e0-1111-2222-3333-444444444444",
+		files: map[string][]byte{
+			"test-results/empty.json": {},
+			"test-results/full.json":  []byte(`{"a":1}`),
+		},
+	}
+	newArtifactAPI(t, store)
+
+	entries, err := listArtifactPath(client.New(), store.scope, store.scopeID, "test-results")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	byName := map[string]artifactEntry{}
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+
+	empty, ok := byName["empty.json"]
+	if !ok {
+		t.Fatalf("empty.json missing from %+v", entries)
+	}
+	if empty.IsDirectory {
+		t.Error("an empty file was reported as a directory")
+	}
+	if empty.Size == nil {
+		t.Fatal("size was dropped for an empty artifact; absence of size is how the API marks a directory")
+	}
+	if *empty.Size != 0 {
+		t.Errorf("size = %d, want 0", *empty.Size)
+	}
+
+	// And it must survive re-serialization, which is what the CLI prints.
+	out, err := json.Marshal(empty)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), `"size":0`) {
+		t.Errorf("re-serialized entry lost its zero size: %s", out)
+	}
+
+	// A directory still has no size at all, so the two stay distinguishable.
+	dirs, err := listArtifactPath(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("list root: %v", err)
+	}
+	for _, d := range dirs {
+		if d.IsDirectory && d.Size != nil {
+			t.Errorf("directory %q gained a size: %+v", d.Name, d)
+		}
+	}
+}
+
+func TestPullRefusesToSkipANonRegularDestination(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	// A directory sits where an artifact should be written.
+	dest := filepath.Join(dir, "summary.json")
+	if err := os.MkdirAll(dest, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	var got pullResult
+	for _, r := range pullFiles(client.New(), []artifactEntry{{Path: "summary.json", Name: "summary.json"}}) {
+		got = r
+	}
+
+	if got.Status == "skipped" {
+		t.Fatal("a directory at the destination was reported as skipped; nothing local holds the artifact")
+	}
+	if got.Status != "failed" {
+		t.Errorf("status = %q, want failed", got.Status)
+	}
+	if !strings.Contains(got.Error, "not a regular file") {
+		t.Errorf("error should say why, got %q", got.Error)
+	}
+}
+
+// --- path safety ---
+
+func TestSafeRelativePathRejectsWhatTheFilesystemWouldNormalise(t *testing.T) {
+	// Windows strips trailing dots and spaces, so these reach the filesystem
+	// as traversals even though no segment is literally "..".
+	unsafe := []string{
+		"..", ".", "", "/etc/passwd", "a\\b",
+		"../x.txt", "a/../b",
+		".. /x.txt", "... /x.txt", ".../x.txt",
+		".. /.. /Startup/run.bat",
+		". /x.txt", "a/.. /b",
+		"a//b",
+	}
+	for _, p := range unsafe {
+		t.Run("rejects "+p, func(t *testing.T) {
+			if rel, err := safeRelativePath(p); err == nil {
+				t.Errorf("accepted %q as %q", p, rel)
+			}
+		})
+	}
+
+	safe := []string{
+		"summary.json", "test-results/junit.xml", "..x/y",
+		"a.b/c.d", "dir.with.dots/file.json", "-leading-dash/x",
+	}
+	for _, p := range safe {
+		t.Run("accepts "+p, func(t *testing.T) {
+			if _, err := safeRelativePath(p); err != nil {
+				t.Errorf("rejected legitimate path %q: %v", p, err)
+			}
+		})
+	}
+}
+
+// Drive-relative paths like "C:x" are dangerous on Windows and an ordinary
+// directory name on Unix, so the verdict is the platform's to make. What must
+// hold everywhere is that safeRelativePath defers to filepath.IsLocal rather
+// than deciding for itself.
+func TestSafeRelativePathDefersToThePlatformOnDriveRelativePaths(t *testing.T) {
+	for _, p := range []string{"C:x/y", "NUL/x", "a/CON"} {
+		_, err := safeRelativePath(p)
+		accepted := err == nil
+		if accepted != filepath.IsLocal(filepath.Join(strings.Split(p, "/")...)) {
+			t.Errorf("%q: accepted=%v but filepath.IsLocal disagrees", p, accepted)
+		}
+	}
+}
+
+func TestContainedInRejectsEscapes(t *testing.T) {
+	root := filepath.Join("out", "artifacts")
+	if containedIn(root, filepath.Join(root, "..", "escaped.txt")) {
+		t.Error("a path above the root was reported as contained")
+	}
+	if containedIn(root, "out") {
+		t.Error("the root's parent was reported as contained")
+	}
+	if !containedIn(root, filepath.Join(root, "a", "b.json")) {
+		t.Error("a path inside the root was reported as outside")
+	}
+}
+
+func TestPullRefusesAPathThatWouldLeaveTheOutputDirectory(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+
+	hostile := []artifactEntry{
+		{Path: "../escape.json", Name: "escape.json"},
+		{Path: ".. /escape.json", Name: "escape.json"},
+		{Path: ".../escape.json", Name: "escape.json"},
+	}
+	for _, r := range pullFiles(client.New(), hostile) {
+		if r.Status != "failed" {
+			t.Errorf("%q: status %q, want failed", r.Path, r.Status)
+		}
+	}
+
+	// Nothing may exist beside the output directory.
+	siblings, err := os.ReadDir(filepath.Dir(dir))
+	if err != nil {
+		t.Fatalf("read parent: %v", err)
+	}
+	for _, e := range siblings {
+		if strings.Contains(e.Name(), "escape") {
+			t.Errorf("a file escaped the output directory: %s", e.Name())
+		}
+	}
+}
+
+// --- the two coverage gaps the review named ---
+
+func TestGetOnADirectoryNamesTheCommandsThatWork(t *testing.T) {
+	store := nestedStore(t)
+	newArtifactAPI(t, store)
+
+	prev := []any{artifactGetScope, artifactGetScopeID, artifactGetPath, artifactGetOutput}
+	t.Cleanup(func() {
+		artifactGetScope = prev[0].(string)
+		artifactGetScopeID = prev[1].(string)
+		artifactGetPath = prev[2].(string)
+		artifactGetOutput = prev[3].(string)
+	})
+	artifactGetScope, artifactGetScopeID = store.scope, store.scopeID
+	artifactGetPath, artifactGetOutput = "test-results", filepath.Join(t.TempDir(), "out.json")
+
+	var out, errOut bytes.Buffer
+	output.SetWriters(&out, &errOut)
+	t.Cleanup(func() { output.SetWriters(nil, nil) })
+
+	err := artifactGetCmd.RunE(artifactGetCmd, nil)
+	if err == nil {
+		t.Fatal("get on a directory must fail, not write something")
+	}
+
+	var reported map[string]any
+	if jsonErr := json.Unmarshal(errOut.Bytes(), &reported); jsonErr != nil {
+		t.Fatalf("stderr is not structured (%v): %q", jsonErr, errOut.String())
+	}
+	if reported["code"] != "is_directory" {
+		t.Errorf("code = %v, want is_directory — a bare 404 reads as 'no such artifact'", reported["code"])
+	}
+	msg, _ := reported["message"].(string)
+	for _, want := range []string{"artifact list", "artifact pull", "test-results"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message should mention %q, got %q", want, msg)
+		}
+	}
+	if _, statErr := os.Stat(artifactGetOutput); statErr == nil {
+		t.Error("nothing should have been written for a directory")
+	}
+}
+
+func TestPullNeverExceedsItsConcurrencyLimit(t *testing.T) {
+	// More files than pullConcurrency, so the semaphore actually binds.
+	files := map[string][]byte{}
+	for i := 0; i < pullConcurrency*25; i++ {
+		files[fmt.Sprintf("shard-%02d/result.json", i)] = []byte(`{"i":1}`)
+	}
+	store := fakeStore{scope: "workflows", scopeID: "c0c0c0c0-1111-2222-3333-444444444444", files: files}
+
+	var mu sync.Mutex
+	var inFlight, maxInFlight, maxGoroutines int
+	api := newArtifactAPI(t, store)
+	api.onBlob = func() {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		// Goroutine count separates "throttled at the source" from "spawned
+		// all at once, then throttled" — both cap in-flight requests, only
+		// one avoids a stack per file.
+		if g := runtime.NumGoroutine(); g > maxGoroutines {
+			maxGoroutines = g
+		}
+		mu.Unlock()
+		time.Sleep(2 * time.Millisecond)
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+	}
+	baseline := runtime.NumGoroutine()
+
+	dir := t.TempDir()
+	setPullFlags(t, store, "", dir, false, false)
+	walkRes, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	for _, r := range pullFiles(client.New(), walkRes.Files) {
+		if r.Status != "downloaded" {
+			t.Fatalf("%s: %s %s", r.Path, r.Status, r.Error)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxInFlight > pullConcurrency {
+		t.Errorf("peaked at %d concurrent downloads, limit is %d", maxInFlight, pullConcurrency)
+	}
+	if maxInFlight < 2 {
+		t.Errorf("peaked at %d — the test never exercised concurrency at all", maxInFlight)
+	}
+	// Throttled at the source, the extra goroutines track pullConcurrency and
+	// the HTTP transport, independent of file count. Spawning first would put
+	// len(files) of them here at once, which for this store is far past the
+	// budget below.
+	if budget := baseline + 100; maxGoroutines > budget {
+		t.Errorf("peaked at %d goroutines (baseline %d, %d files); the limit should throttle before spawning, not after",
+			maxGoroutines, baseline, len(files))
+	}
+}
+
+// --- throttling is org-wide: stop, do not walk into it ---
+
+func TestWalkStopsOnRateLimitInsteadOfAmplifyingIt(t *testing.T) {
+	store := nestedStore(t)
+	// The root lists fine; the first subdirectory is throttled. The budget is
+	// per organization and windowed, so every later listing would be
+	// throttled too.
+	store.failList = map[string]int{
+		"test-results": http.StatusTooManyRequests,
+		"timing":       http.StatusTooManyRequests,
+		"agent":        http.StatusTooManyRequests,
+		"compilation":  http.StatusTooManyRequests,
+	}
+	api := newArtifactAPI(t, store)
+
+	_, err := walkArtifacts(client.New(), store.scope, store.scopeID, "")
+	if err == nil {
+		t.Fatal("a 429 must abort the walk; continuing spends more of the budget that is already exhausted")
+	}
+	if statusOf(err) != http.StatusTooManyRequests {
+		t.Errorf("status = %d, want 429", statusOf(err))
+	}
+	// Count distinct directories, not raw requests: the client retries a 429
+	// internally, so one logical listing is several HTTP calls. Which
+	// subdirectory is reached first is not fixed — listings come back in map
+	// order — so the assertion is on how many were tried, not which.
+	distinct := map[string]bool{}
+	for _, p := range api.listCalls {
+		distinct[p] = true
+	}
+	if len(distinct) != 2 {
+		t.Errorf("listed %d distinct paths (%v); expected the root plus exactly one throttled directory before stopping",
+			len(distinct), api.listCalls)
+	}
+	if !distinct[""] {
+		t.Error("the root listing is missing")
+	}
+}
+
+func TestRateLimitIsReportedAsSuchRatherThanAsAGenericError(t *testing.T) {
+	store := nestedStore(t)
+	store.failList = map[string]int{"": http.StatusTooManyRequests}
+	newArtifactAPI(t, store)
+
+	_, stderr, err := runPullCmd(t, "--scope", store.scope, "--id", store.scopeID, "--output-dir", t.TempDir())
+	if err == nil {
+		t.Fatal("a throttled pull must not report success")
+	}
+
+	var reported map[string]any
+	if jsonErr := json.Unmarshal([]byte(stderr), &reported); jsonErr != nil {
+		t.Fatalf("stderr is not structured (%v): %q", jsonErr, stderr)
+	}
+	if reported["code"] != "rate_limited" {
+		t.Errorf("code = %v, want rate_limited", reported["code"])
+	}
+	if got, _ := reported["status"].(float64); got != http.StatusTooManyRequests {
+		t.Errorf("status = %v, want 429", reported["status"])
+	}
+	msg, _ := reported["message"].(string)
+	// It must not send the user to the fix for a different problem: waiting
+	// helps here, and unlike a missing directory, retrying eventually works.
+	if !strings.Contains(msg, "wait") {
+		t.Errorf("message should tell the user to wait, got %q", msg)
+	}
+	if strings.Contains(msg, "Retrying will not") {
+		t.Errorf("a throttle IS worth retrying later; message must not say otherwise: %q", msg)
+	}
+}
+
+func TestOrgWideRefusalCoversOnlyOrgWideStatuses(t *testing.T) {
+	for status, want := range map[int]bool{
+		http.StatusUnauthorized:        true,
+		http.StatusForbidden:           true,
+		http.StatusTooManyRequests:     true,
+		http.StatusNotFound:            false, // one subtree, removed by retention
+		http.StatusInternalServerError: false, // transient
+		http.StatusBadGateway:          false,
+	} {
+		if got := orgWideRefusal(status); got != want {
+			t.Errorf("orgWideRefusal(%d) = %v, want %v", status, got, want)
+		}
+	}
+}
+
+func TestDefaultCapLeavesRoomInTheOrganisationBudget(t *testing.T) {
+	// The artifacts API enforces a per-organization request budget over a
+	// short window, and pull spends a signed-URL request per file on top of
+	// its listings. A default large enough to consume that budget would
+	// throttle the whole organization on one command, so it stays modest;
+	// SEM_AI_MAX_ARTIFACT_LISTINGS is the way up for a store that needs it.
+	const ceiling = 500
+	if defaultMaxWalkRequests > ceiling {
+		t.Errorf("default cap is %d; keep it at or below %d so one command cannot exhaust the organization's budget",
+			defaultMaxWalkRequests, ceiling)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -65,10 +66,17 @@ func NewTraceParent() {
 }
 
 const (
-	maxRetries     = 5
-	baseDelay      = 100 * time.Millisecond
-	maxDelay       = 2 * time.Second
-	defaultTimeout = 30 * time.Second
+	maxRetries = 5
+	baseDelay  = 100 * time.Millisecond
+	maxDelay   = 2 * time.Second
+	// maxRetryAfterWait bounds how long a Retry-After header may park the
+	// process. Beyond it the request fails immediately, carrying the advised
+	// delay, so a caller can say how long to wait rather than appearing hung
+	// — a per-organization throttle window is measured in minutes, and eight
+	// concurrent download workers each sleeping that long is worse than one
+	// clear error.
+	maxRetryAfterWait = 10 * time.Second
+	defaultTimeout    = 30 * time.Second
 )
 
 type Client struct {
@@ -360,14 +368,63 @@ func (c *Client) GetExternal(rawURL string) (*Response, error) {
 	return &Response{Body: body, StatusCode: resp.StatusCode, Headers: resp.Header}, nil
 }
 
+// HTTPError is returned when retries are exhausted against a response that
+// carried a status. Without it the status is lost, and a caller cannot tell a
+// rate limit apart from a server fault — which matters because they call for
+// opposite responses: back off and wait, or fail the one request.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+	Attempts   int
+	// RetryAfter is what the server asked us to wait, when it said so. Zero
+	// means the response carried no usable Retry-After.
+	RetryAfter time.Duration
+}
+
+func (e *HTTPError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("HTTP %d: %s (retry after %s)", e.StatusCode, e.Body, e.RetryAfter)
+	}
+	return fmt.Sprintf("HTTP %d: %s (failed after %d retries)", e.StatusCode, e.Body, e.Attempts-1)
+}
+
+// parseRetryAfter reads the header in both forms RFC 9110 allows: a delay in
+// seconds, or an HTTP-date. Anything unparseable or in the past yields 0,
+// which leaves the caller on its own backoff.
+func parseRetryAfter(h http.Header, now time.Time) time.Duration {
+	raw := strings.TrimSpace(h.Get("Retry-After"))
+	if raw == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(raw); err == nil {
+		if secs <= 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if when, err := http.ParseTime(raw); err == nil {
+		if d := when.Sub(now); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
 func (c *Client) doWithRetry(method, u string, body []byte) (*Response, error) {
 	var lastErr error
+	var lastStatus int
+	var lastBody string
+	var retryAfterWait time.Duration
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
 			delay := time.Duration(math.Min(
 				float64(baseDelay)*math.Pow(2, float64(attempt-1)),
 				float64(maxDelay),
 			))
+			if retryAfterWait > 0 {
+				delay = retryAfterWait
+				retryAfterWait = 0
+			}
 			log.Printf("retry %d/%d after %v", attempt, maxRetries, delay)
 			time.Sleep(delay)
 		}
@@ -380,11 +437,30 @@ func (c *Client) doWithRetry(method, u string, body []byte) (*Response, error) {
 
 		// Retry on 5xx and 429
 		if resp.StatusCode >= 500 || resp.StatusCode == 429 {
-			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(resp.Body))
+			lastStatus, lastBody = resp.StatusCode, string(resp.Body)
+			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, lastBody)
+
+			// A server that says how long to wait knows better than our
+			// backoff curve does. Honour it when it is short; when it is
+			// longer than we are willing to block, stop now and report it —
+			// retrying inside a window we were just told to sit out only
+			// spends more of the budget that is already exhausted.
+			if wait := parseRetryAfter(resp.Headers, time.Now()); wait > 0 {
+				if wait > maxRetryAfterWait {
+					return nil, &HTTPError{
+						StatusCode: lastStatus, Body: lastBody,
+						Attempts: attempt + 1, RetryAfter: wait,
+					}
+				}
+				retryAfterWait = wait
+			}
 			continue
 		}
 
 		return resp, nil
+	}
+	if lastStatus != 0 {
+		return nil, &HTTPError{StatusCode: lastStatus, Body: lastBody, Attempts: maxRetries + 1}
 	}
 	return nil, fmt.Errorf("request failed after %d retries: %w", maxRetries, lastErr)
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // newTestClient creates a Client that points to the given test server host.
@@ -578,8 +580,8 @@ func TestResponseBodyAndStatus(t *testing.T) {
 
 func TestHTTPMethods(t *testing.T) {
 	tests := []struct {
-		name   string
-		fn     func(c *Client, srv *httptest.Server) (*Response, error)
+		name       string
+		fn         func(c *Client, srv *httptest.Server) (*Response, error)
 		wantMethod string
 	}{
 		{
@@ -688,5 +690,129 @@ func TestPostYAMLEndpointURL(t *testing.T) {
 	wantPath := "/api/v1alpha/yaml"
 	if gotPath != wantPath {
 		t.Errorf("path = %q, want %q", gotPath, wantPath)
+	}
+}
+
+// ---- Retry-After ---------------------------------------------------------------
+
+func TestParseRetryAfterAcceptsBothFormsRFC9110Allows(t *testing.T) {
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name, header string
+		want         time.Duration
+	}{
+		{"delay seconds", "120", 120 * time.Second},
+		{"one second", "1", time.Second},
+		{"http date in the future", now.Add(90 * time.Second).UTC().Format(http.TimeFormat), 90 * time.Second},
+		{"http date in the past", now.Add(-90 * time.Second).UTC().Format(http.TimeFormat), 0},
+		{"zero", "0", 0},
+		{"negative", "-5", 0},
+		{"garbage", "soon", 0},
+		{"absent", "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.header != "" {
+				h.Set("Retry-After", tc.header)
+			}
+			// HTTP-date has one-second resolution, so allow a second of slack.
+			got := parseRetryAfter(h, now)
+			if diff := got - tc.want; diff > time.Second || diff < -time.Second {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShortRetryAfterIsHonouredInsteadOfTheBackoffCurve(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(429)
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(strings.TrimPrefix(srv.URL, "http://"), "tok")
+	start := time.Now()
+	resp, err := c.Get("items", "x")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("a short Retry-After should be waited out, got %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	// The default first backoff is 100ms; honouring the header means ~1s.
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("waited %v — the Retry-After header was ignored in favour of the backoff curve", elapsed)
+	}
+}
+
+func TestLongRetryAfterFailsFastAndReportsTheAdvisedWait(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Retry-After", "300")
+		w.WriteHeader(429)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(strings.TrimPrefix(srv.URL, "http://"), "tok")
+	start := time.Now()
+	_, err := c.Get("items", "x")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	// Blocking for the full window would look like a hang, and eight
+	// concurrent workers doing it is worse than one clear error.
+	if elapsed > 5*time.Second {
+		t.Errorf("blocked for %v; a long Retry-After must fail fast", elapsed)
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Errorf("made %d requests; a window we were told to sit out must not be retried", n)
+	}
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error should be *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", httpErr.StatusCode)
+	}
+	if httpErr.RetryAfter != 300*time.Second {
+		t.Errorf("RetryAfter = %v, want 5m0s", httpErr.RetryAfter)
+	}
+	if !strings.Contains(err.Error(), "retry after") {
+		t.Errorf("message should state the advised wait, got %q", err.Error())
+	}
+}
+
+func TestRetryExhaustedPreservesTheStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`throttled`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(strings.TrimPrefix(srv.URL, "http://"), "tok")
+	_, err := c.Get("items", "x")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("status must survive retry exhaustion; got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429 — a caller cannot tell a throttle from a fault without it", httpErr.StatusCode)
 	}
 }


### PR DESCRIPTION
## Problem

An artifact store is a tree, but the CLI could only see its top level. `artifact list` never sent the `path` parameter the API already accepts, so directories showed up as leaves with no way to open them — no way to discover filenames inside any of them from the CLI, and no way to bulk-pull a workflow's artifacts at all. `artifact get` pointed at a directory answered a bare `HTTP 404`, which reads as "this artifact does not exist".

## What's in

All client-side; no API change. The endpoint accepted `path` all along.

- **`artifact list --path <dir>`** — list one directory level deeper.
- **`artifact list --recursive`** — walk every subdirectory and return the flattened file list, sorted.
- **`artifact pull`** — bulk download a subtree, mirroring the remote layout under `--output-dir`. Skips files already present unless `--force`, `--dry-run` lists without writing, per-file failures are reported individually without aborting the rest, and downloads run 8-wide since each file costs a signed-URL call plus a blob fetch.
- **`artifact get` on a directory** now returns `"code": "is_directory"` and names the two commands that do work on one.

MCP picks all of this up for free — tools are generated by walking the cobra tree. That is also why several decisions below are stricter than they would be for a purely human CLI.

## Contracts worth reviewing

These are behavioural decisions rather than implementation details, so they are the parts most worth disagreeing with.

**A partial result never exits zero.** `list --recursive`, `pull` and `pull --dry-run` share one rule: if the walk could not see the whole tree — a directory failed to list, or the walk hit its listing cap — the command prints what it found on stdout, sets `"complete": false`, and exits non-zero. `complete` is the one signal all three share and the one to key off; `status` additionally distinguishes `pulled_partial` from `dry_run_partial` for human readers. Details arrive in `errors` and, for a capped walk, `truncated` + `unvisited_directories`. The files it did find are still written. The error states whether retrying can help, which differs by cause: a directory removed by retention will not come back, a rate limit will clear.

**A file on disk never contradicts its own name.** Both `get` and `pull` decide gzip handling from the local destination filename: a path ending `.gz`/`.gzip`/`.tgz`/`.svgz` keeps its bytes, anything else is inflated if the payload is gzip. Streaming to stdout has no name to contradict, so it always inflates. Previously `get` inflated unconditionally, so the same artifact produced different bytes depending on which command fetched it.

**Refusals that apply to the whole organization stop the walk.** A 404 mid-walk means retention removed that subtree, so it is recorded and the walk continues — losing every file found so far to one expired directory is worse than reporting the gap. A 401, 403 or 429 applies to the organization rather than to this path, so every remaining listing would answer identically; continuing only multiplies one refusal into hundreds, and for a rate limit the extra requests push recovery further out. A failure listing the root is always fatal.

**`--output-dir` defaults to `./artifacts-<id>`, never the working directory.** With MCP tools generated from the cobra tree, a default of `.` meant an agent calling `artifact_pull` without an output directory emptied an artifact tree into the user's repo root.

**The listing budget is bounded and tunable.** A walk issues at most 500 directory listings, overridable with `SEM_AI_MAX_ARTIFACT_LISTINGS`. A value that is not a positive integer is reported and ignored — a cap of zero would truncate every walk to nothing while describing it as ordinary truncation. The bound exists because the artifacts API enforces a per-organization request budget over a short window, shared by every consumer in that organization, and `pull` spends a signed-URL request per file on top of its listings; one command should not be able to exhaust it. It is not a cost control — artifact billing meters storage and egress, not request counts.

**The feature gate is named.** The artifacts API requires both the `artifacts` and `artifacts_api` features, and a plan may enable one without the other, so a 403 used to surface as an opaque `api_error` and sent people debugging their scope ID. It now reports `"code": "feature_disabled"` with status 403. Verified against an organization with the gate disabled: all three commands report it, and a recursive list returns immediately instead of walking into the cap.

## Shared client changes

This PR also touches `pkg/client`, which every command uses. Two changes, both small, both prompted by the artifact commands being the first to issue many requests per user action:

- **The HTTP status now survives retry exhaustion.** `doWithRetry` previously returned a bare `fmt.Errorf`, so a caller could not tell a rate limit from a server fault — which matters because they call for opposite responses. It now returns a typed `HTTPError` carrying status, body and advised wait. This is what makes the walk's status-based handling possible at all; without it the 429 rule above silently did nothing.
- **`Retry-After` is honoured**, in both forms RFC 9110 allows. A short wait is slept in place of the backoff curve. A wait longer than ten seconds fails immediately and reports the advised delay, because blocking for a window the server just told us to sit out looks like a hang, and eight concurrent download workers each doing it is worse than one clear error. The retry policy is otherwise unchanged — a transient 429 that clears still succeeds on retry, and the existing retry tests still hold.

## Design notes

- **Downloads are written through a temporary file and renamed.** A plain write leaves a truncated file behind when interrupted, and the next run's skip check accepts it as complete — corruption that survives retries. The temporary file is opened directly rather than via `os.CreateTemp` so the caller's umask still applies (`CreateTemp` plus `Chmod` made artifacts world-readable under a restrictive umask), and its name uses a short fixed prefix rather than one derived from the artifact, which overflowed `NAME_MAX` for long names a plain write accepts.
- **The skip check uses `Lstat` and accepts only a regular file.** A directory or device at the destination is a conflict, not a skip; reporting it as skipped exits zero while nothing local holds the bytes.
- **`artifactEntry.Size` is a pointer.** The API omits `size` for directories and only for directories, so absence of size is how a directory is marked. An `int64` with `omitempty` erased `"size": 0` and made an empty artifact indistinguishable from a directory.
- **Decompression failures fail the file.** `gunzip` returns an error instead of the still-compressed bytes, so a corrupt payload is never written under a name claiming otherwise and counted as downloaded.
- **Path segments are judged by what the filesystem would make of them, not by their literal text.** Windows strips trailing dots and spaces, so `.. ` and `...` arrive as `..`; a segment that reduces to empty, `.` or `..` after that trimming is rejected. A lexical containment check does not close this — `filepath.Rel` and `filepath.IsLocal` both read `.. ` as an ordinary component, because the normalisation happens below them. `IsLocal` is still applied for what it does cover (drive-relative paths, reserved device names), and the joined destination is confirmed to sit inside `--output-dir` as a second barrier.
- **The walk keeps a visited set.** A store reporting an already-walked directory would otherwise loop to the request cap, re-emitting its files on every pass and leaving duplicates to race on one destination during download.
- **`pullFiles` acquires its concurrency slot before spawning**, not inside the goroutine, so a large tree does not create one goroutine per file and then throttle them.

## Testing

- 59 Go tests against an `httptest` fake of the artifacts + signed-URL + blob endpoints: descent, recursion, cycle termination, cap truncation and the env override, sort order, path-escape rejection, gzip handling in both directions and for every gzip-named suffix, skip/force idempotency, per-file failure isolation, the feature gate against the exact production 403 body, rate-limit handling, `get` pointed at a directory, the concurrency limit actually binding, and the incompleteness contract driven through the commands rather than their helpers.
- Every fix was checked by reverting it and confirming a test fails. **Five tests did not survive that check when first written and were rewritten:** two derived their expectation from the function under test, so a regression moved both sides together; one asserted a property a plain `os.WriteFile` also satisfies, and was replaced by an inode comparison, since rename replaces the inode and in-place truncation keeps it; one measured peak in-flight requests when the property under test was peak goroutine count, which is the only thing distinguishing the two arrangements; and one was order-dependent, passing about two runs in five, because Go randomises map iteration and the assertion had hard-coded which directory came first. One mutation is deliberately uncaught — removing the containment check in `pullOne` fails nothing, because no path survives the segment rules to reach it, which is the point of a second barrier.
- Live-verified against a real workflow: `--path`, `--recursive`, full pull, idempotent re-pull, `--force`, `--dry-run` writing nothing, `0644`/`0600` under differing umasks, no temporary files left behind, the directory error on `get`, and identical content whether an artifact is fetched by `get` or by `pull`. A real `test-results/junit.json` is stored gzipped *without* a `.gz` name (8,743 bytes remote, 126,995 on disk), so the hidden-gzip path is exercised against real data.
- One gap: no `.gz`-*named* artifact exists in the organizations available, so that branch rests on unit tests and mutation checks rather than live bytes.

## Follow-ups, not in this PR

- **Streaming downloads.** Each body is buffered via `io.ReadAll`, so a tree with a few very large artifacts is held in memory. `io.Copy` into the temporary file would fix it, but it needs a streaming variant of the shared client's external-fetch API and belongs in its own change.
- **Deduplication.** This is now the third signed-URL download path in `cmd/`; one copy belongs in `pkg/`.
- **Server-side listing.** `artifacthub` supports `unwrap_directories`, which would collapse the client-side walk into a single server-side prefix scan and delete `walkArtifacts`, the cap and the truncation reporting. It cannot be adopted as-is: the listing RPC has no pagination, so unwrapping trades N bounded requests for one unbounded response — no partial result, no truncation signal, no resume. The order is: paginate the listing RPC, expose it through the public API, then simplify the client.
